### PR TITLE
Require org-habit to use org-habit features.

### DIFF
--- a/org-ql-agenda.el
+++ b/org-ql-agenda.el
@@ -30,6 +30,7 @@
 ;;; Code:
 
 (require 'org)
+(require 'org-habit)
 (require 'org-agenda)
 (require 'dash)
 (require 'cl-lib)


### PR DESCRIPTION
org-habit is required to use org-is-habit-p. 
org-ql-agenda doesn't work without it.