### PR TITLE
Rename `org-timestamp--to-internal-time' into `org-timestamp-to-time'

### DIFF
--- a/org-ql.el
+++ b/org-ql.el
@@ -27,6 +27,10 @@
 
 ;;;; Variables
 
+(if (fboundp 'org-timestamp--to-internal-time)
+    (defalias 'org-timestamp-to-time 'org-timestamp--to-internal-time)
+  nil)
+
 (defvar org-ql--today nil)
 
 (defvar org-ql-cache (make-hash-table :weakness 'key)
@@ -362,8 +366,8 @@ ignored."
                 (test-timestamps (pred-form)
                                  `(cl-loop for next-ts = (next-timestamp)
                                            while next-ts
-                                           for beg = (float-time (org-timestamp--to-internal-time next-ts))
-                                           for end = (float-time (org-timestamp--to-internal-time next-ts 'end))
+                                           for beg = (float-time (org-timestamp-to-time next-ts))
+                                           for end = (float-time (org-timestamp-to-time next-ts 'end))
                                            thereis ,pred-form)))
     (save-excursion
       (let ((end-pos (org-entry-end-position)))
@@ -518,8 +522,8 @@ FROM, TO, and ON should be strings parseable by
                 (test-timestamps (pred-form)
                                  `(cl-loop for next-ts = (next-timestamp)
                                            while next-ts
-                                           for beg = (float-time (org-timestamp--to-internal-time next-ts))
-                                           for end = (float-time (org-timestamp--to-internal-time next-ts 'end))
+                                           for beg = (float-time (org-timestamp-to-time next-ts))
+                                           for end = (float-time (org-timestamp-to-time next-ts 'end))
                                            thereis ,pred-form)))
     (save-excursion
       (let ((end-pos (org-entry-end-position)))
@@ -558,8 +562,8 @@ FROM, TO, and ON should be strings parseable by
                                  `(cl-loop for next-ts = (next-timestamp)
                                            while next-ts
                                            when (string-prefix-p "<" next-ts)
-                                           for beg = (float-time (org-timestamp--to-internal-time next-ts))
-                                           for end = (float-time (org-timestamp--to-internal-time next-ts 'end))
+                                           for beg = (float-time (org-timestamp-to-time next-ts))
+                                           for end = (float-time (org-timestamp-to-time next-ts 'end))
                                            thereis ,pred-form)))
     (save-excursion
       (let ((end-pos (org-entry-end-position)))
@@ -598,8 +602,8 @@ FROM, TO, and ON should be strings parseable by
                                  `(cl-loop for next-ts = (next-timestamp)
                                            while next-ts
                                            when (string-prefix-p "[" next-ts)
-                                           for beg = (float-time (org-timestamp--to-internal-time next-ts))
-                                           for end = (float-time (org-timestamp--to-internal-time next-ts 'end))
+                                           for beg = (float-time (org-timestamp-to-time next-ts))
+                                           for end = (float-time (org-timestamp-to-time next-ts 'end))
                                            thereis ,pred-form)))
     (save-excursion
       (let ((end-pos (org-entry-end-position)))


### PR DESCRIPTION
I tried using the `org-ql` library and I got a complaint about the `org-timestamp--to-internal-time`. I use version 9.2.3 which is fairly recent and also checked that this change happened one year ago on an [orgmode repo commit](https://code.orgmode.org/asultramosesdili/org-mode/commit/728920a8edf7e24ae1656b2a6bfaeb7c58b15012).

I am not very savvy with emacs, by the way, and I didn't manage to run `make test` successfully. I got:
```
cask exec buttercup -L .
make: cask: No such file or directory
make: *** [test] Error 1
```

I would appreciate any help to run the tests to confirm this change is ok. I just tested with a custom script.