### PR TITLE
Remove byte-compile warnings and make compatible with org>=9.2

### DIFF
--- a/org-ql-agenda.el
+++ b/org-ql-agenda.el
@@ -50,6 +50,9 @@
 (defvar org-super-agenda-groups)
 (declare-function org-super-agenda--group-items "org-super-agenda")
 
+(when (version< org-version "9.2")
+  (defalias 'org-get-tags 'org-get-tags-at))
+
 ;;;; Variables
 
 (defvar org-ql-agenda-buffer-name "*Org Agenda NG*"
@@ -328,8 +331,8 @@ Its property list should be the second item in the list, as returned by `org-ele
                        (if-let ((marker (or (org-element-property :org-hd-marker element)
                                             (org-element-property :org-marker element))))
                            (with-current-buffer (marker-buffer marker)
-                             ;; I wish `org-get-tags-at' used the correct buffer automatically.
-                             (org-get-tags-at marker (not org-use-tag-inheritance)))
+                             ;; I wish `org-get-tags' used the correct buffer automatically.
+                             (org-get-tags marker (not org-use-tag-inheritance)))
                          ;; No marker found
                          (warn "No marker found for item: %s" title)
                          (org-element-property :tags element))

--- a/org-ql-agenda.el
+++ b/org-ql-agenda.el
@@ -33,6 +33,7 @@
 
 (require 'cl-lib)
 (require 'org)
+(require 'org-element)
 (require 'org-agenda)
 (require 'seq)
 (require 'rx)
@@ -41,6 +42,13 @@
 
 (require 'dash)
 (require 's)
+
+;;;; Compatibility
+
+(defvar org-super-agenda-groups)
+(defvar org-super-agenda-auto-selector-keywords)
+(defvar org-super-agenda-groups)
+(declare-function org-super-agenda--group-items "org-super-agenda")
 
 ;;;; Variables
 

--- a/org-ql.el
+++ b/org-ql.el
@@ -25,6 +25,12 @@
 
 (require 'dash)
 
+;;;; Compatibility
+
+(when (version< org-version "9.2")
+  (defalias 'org-get-tags 'org-get-tags-at)
+  (defalias 'org-timestamp-to-time 'org-timestamp--to-internal-time))
+
 ;;;; Variables
 
 (defvar org-ql--today nil)
@@ -457,8 +463,8 @@ With KEYWORDS, return non-nil if its keyword is one of KEYWORDS (a list of strin
 (org-ql--defpredicate tags (&rest tags)
   "Return non-nil if current heading has one or more of TAGS (a list of strings)."
   ;; TODO: Try to use `org-make-tags-matcher' to improve performance.  It would be nice to not have
-  ;; to run `org-get-tags-at' for every heading, especially with inheritance.
-  (when-let ((tags-at (org-get-tags-at (point) (not org-use-tag-inheritance))))
+  ;; to run `org-get-tags' for every heading, especially with inheritance.
+  (when-let ((tags-at (org-get-tags (point) (not org-use-tag-inheritance))))
     (cl-typecase tags
       (null t)
       (otherwise (seq-intersection tags tags-at)))))


### PR DESCRIPTION
This is another version of #27 and also fixes the
changed `org-get-tags-at` function.

It also fixes most byte-compile warnings.
The only warnings left are:
```
org-ql.el:347:23:Warning: Unused lexical variable ‘beg’
org-ql.el:347:23:Warning: Unused lexical variable ‘end’
org-ql.el:347:23:Warning: Unused lexical variable ‘on’
org-ql.el:501:23:Warning: Unused lexical variable ‘beg’
org-ql.el:501:23:Warning: Unused lexical variable ‘end’
org-ql.el:501:23:Warning: Unused lexical variable ‘on’
org-ql.el:538:23:Warning: Unused lexical variable ‘beg’
org-ql.el:538:23:Warning: Unused lexical variable ‘end’
org-ql.el:538:23:Warning: Unused lexical variable ‘on’
org-ql.el:578:23:Warning: Unused lexical variable ‘beg’
org-ql.el:578:23:Warning: Unused lexical variable ‘end’
org-ql.el:578:23:Warning: Unused lexical variable ‘on’
```

Which happen because we call `byte-compile` manually.
See [this SO thread](https://emacs.stackexchange.com/questions/45231/warning-unused-lexical-variable-xxxxx-for-clearly-used-variables)
for more info.