### PR TITLE
Add: org-ql-occur

### DIFF
--- a/org-ql.el
+++ b/org-ql.el
@@ -1019,7 +1019,7 @@ will be kept, to allow stacking of calls to this command."
   (unless keep-previous
     (org-remove-occur-highlights nil nil t))
   ;; (push (cons regexp callback) org-occur-parameters)
-  (let ((result (org-ql-query (current-buffer) query
+  (let ((result (org-ql-select (current-buffer) query
                   :action
                   (lambda ()
                     (when org-highlight-sparse-tree-matches

--- a/org-ql.el
+++ b/org-ql.el
@@ -1012,7 +1012,10 @@ function).
 The tree will show the lines where the query matches, and any other context
 defined in `org-show-context-detail', which see.
 
-When optional argument KEEP-PREVIOUS is non-nil, highlighting and
+BUFFER is the buffer to work on.  If omitted, it defaults to
+the current buffer.
+
+When KEEP-PREVIOUS is non-nil, highlighting and
 exposing done by a previous call to `org-occur' or `org-ql-occur'
 will be kept, to allow stacking of calls to this command."
   (interactive (list (read-minibuffer "Query: ")))

--- a/org-ql.el
+++ b/org-ql.el
@@ -1003,7 +1003,7 @@ A and B are Org headline elements."
 
 ;;;; Functions/Occur
 
-(cl-defun org-ql-occur (query &key keep-previous)
+(cl-defun org-ql-occur (query &key (buffer (current-buffer)) keep-previous)
   "Make a compact tree which shows all matches of the query.
 
 QUERY is an `org-ql' query sexp (quoted, since this is a
@@ -1019,7 +1019,7 @@ will be kept, to allow stacking of calls to this command."
   (unless keep-previous
     (org-remove-occur-highlights nil nil t))
   ;; (push (cons regexp callback) org-occur-parameters)
-  (let ((result (org-ql-select (current-buffer) query
+  (let ((result (org-ql-select buffer query
                   :action
                   (lambda ()
                     (when org-highlight-sparse-tree-matches

--- a/org-ql.el
+++ b/org-ql.el
@@ -1003,6 +1003,7 @@ A and B are Org headline elements."
 
 ;;;; Functions/Occur
 
+;;;###autoload
 (cl-defun org-ql-occur (query &key (buffer (current-buffer)) keep-previous)
   "Make a compact tree which shows all matches of the query.
 

--- a/org-ql.el
+++ b/org-ql.el
@@ -1003,7 +1003,7 @@ A and B are Org headline elements."
 
 ;;;; Functions/Occur
 
-(defun org-ql-occur (query &optional keep-previous callback)
+(cl-defun org-ql-occur (query &key keep-previous)
   "Make a compact tree which shows all matches of the query.
 
 QUERY is an `org-ql' query sexp (quoted, since this is a
@@ -1014,12 +1014,7 @@ defined in `org-show-context-detail', which see.
 
 When optional argument KEEP-PREVIOUS is non-nil, highlighting and
 exposing done by a previous call to `org-occur' or `org-ql-occur'
-will be kept, to allow stacking of calls to this command.
-
-Optional argument CALLBACK can be a function of no argument.  In this case,
-it is called with point at the end of the match, match data being set
-accordingly.  Current match is shown only if the return value is non-nil.
-The function must neither move point nor alter narrowing."
+will be kept, to allow stacking of calls to this command."
   (interactive (list (read-minibuffer "Query: ")))
   (unless keep-previous
     (org-remove-occur-highlights nil nil t))
@@ -1027,12 +1022,10 @@ The function must neither move point nor alter narrowing."
   (let ((result (org-ql-query (current-buffer) query
                   :action
                   (lambda ()
-                    (when (or (not callback)
-                              (funcall callback))
-                      (when org-highlight-sparse-tree-matches
-                        (org-highlight-new-match (match-beginning 0) (match-end 0)))
-                      (org-show-context 'occur-tree)
-                      t)))))
+                    (when org-highlight-sparse-tree-matches
+                      (org-highlight-new-match (match-beginning 0) (match-end 0)))
+                    (org-show-context 'occur-tree)
+                    t))))
     (when org-remove-highlights-with-change
       (add-hook 'before-change-functions 'org-remove-occur-highlights
                 nil 'local))


### PR DESCRIPTION
Hi,

I've implemented an `org-ql` equivalent to `org-occur`. Most of the code has been stolen from the definition of `org-occur` in `org.el`, and it's briefly tested. I would like you to review the spec and the implementation.

A few notes:

- Instead of supporting multiple files/buffers, it runs on the current buffer, because this is how `org-occur` works. 
- It may be possible to integrate it with org-agenda by tweaking the action function to return elements with headline markers, but I didn't go so far.

What do you think? If you like the feature, please feel free to merge it.