### PR TITLE
Fix #35: set org-agenda-type for org-ql buffer content

### DIFF
--- a/README.org
+++ b/README.org
@@ -481,6 +481,7 @@ Expands into a call to ~org-ql-select~ with the same arguments.  For convenience
 +  Variable =org-ql-block-header=, which overrides the default header in =org-ql-block= agenda blocks.
 +  Predicate =(path)=.
 +  Option =org-ql-views= may now be customized in a guided, structured way with the customization UI (e.g. =M-x customize-option RET org-ql-views RET=, or press =c= in the =org-ql-view-sidebar= buffer).
++  Enable more Org Agenda commands in =org-ql-view= buffers (e.g. setting deadlines and scheduling).  (Fixes [[https://github.com/alphapapa/org-ql/issues/35][#35]].  Thanks to [[https://github.com/mz-pdm][Milan Zamazal]] and [[https://github.com/mskorzhinskiy][Mikhail Skorzhinskii]].)
 
 *Changed*
 +  Predicate =heading= now accepts multiple regexps, which are matched with boolean =AND=.

--- a/org-ql-view.el
+++ b/org-ql-view.el
@@ -490,6 +490,7 @@ return an empty string."
            ;; FIXME: Use proper prefix
            (concat "  " it)
            (org-add-props it properties
+             'org-agenda-type 'search
              'todo-state todo-keyword
              'tags tag-list
              'org-habit-p habit-property)))))


### PR DESCRIPTION
Some functions in org-agenda checking against org-agenda-type variable to
ensure that this action is valid to run in that type of agenda. Notably
this fix running 'org-agenda-schedule' and 'org-agenda-deadline'
functions.

Also setting agenda type to 'search' prohibits some of the functions that
are still not working on in these buffers, like
"org-agenda-do-date-earlier".