### PR TITLE
Require map in org-ql.el.

### DIFF
--- a/org-ql.el
+++ b/org-ql.el
@@ -34,6 +34,7 @@
 ;;;; Requirements
 
 (require 'cl-lib)
+(require 'map)
 (require 'org)
 (require 'org-element)
 (require 'org-habit)

--- a/org-ql.el
+++ b/org-ql.el
@@ -52,9 +52,8 @@
       (defalias 'org-timestamp-to-time #'org-timestamp--to-internal-time)
       (defun org-ql--get-tags (&optional pos local)
         (org-get-tags-at pos local)))
-  (defun org-ql--get-tags (&rest _ignore)
-    "Call `org-get-tags', ignoring arguments."
-    (org-get-tags)))
+  (defun org-ql--get-tags (&optional pos local)
+    (org-get-tags pos local)))
 
 ;;;; Constants
 


### PR DESCRIPTION
- `org-ql.el` has one invocation of `map-put`, so the `require` is needed.

- In Org 9.2, `org-get-tags` takes optional `pos` and `local` arguments. Four tests fail for me without them.