### PR TITLE
Some improve 

### DIFF
--- a/org-ql.el
+++ b/org-ql.el
@@ -575,6 +575,11 @@ Replaces bare strings with (regexp) selectors, and appropriate
                       ;; "h" alias.
                       `(heading ,@args))
 
+                     ;; Regexps.
+                     (`(r . ,args)
+                      ;; "r" alias.
+                      `(regexp ,@args))
+
                      ;; Outline paths.
                      (`(,(or 'outline-path 'olp) . ,strings)
                       ;; Regexp quote headings.
@@ -1127,7 +1132,7 @@ priority B)."
   "Return non-nil if entry is a habit."
   (org-is-habit-p))
 
-(org-ql--defpred regexp (&rest regexps)
+(org-ql--defpred (regexp r) (&rest regexps)
   "Return non-nil if current entry matches all of REGEXPS (regexp strings)."
   (let ((end (or (save-excursion
                    (outline-next-heading))

--- a/org-ql.el
+++ b/org-ql.el
@@ -109,6 +109,10 @@ the value returned by it at that node.")
   "Plist of predicates, their corresponding functions, and their docstrings.
 This list should not contain any duplicates.")
 
+
+(defvar org-ql-default-predicate 'regexp
+  "The default predicate used by `org-ql--plain-query'.")
+
 ;;;; Customization
 
 (defgroup org-ql nil
@@ -1495,7 +1499,8 @@ Builds the PEG expression using predicates defined in
                             (-sort (-on #'> #'length)))))
       `(cl-defun org-ql--plain-query (input &optional (boolean 'and))
          "Return query parsed from plain query string INPUT.
-Multiple predicates are combined with BOOLEAN."
+Multiple predicates are combined with BOOLEAN.
+If no predicates are found, `org-ql-default-predicate' will be used."
          (unless (s-blank-str? input)
            (let* ((query (peg-parse-string
                           ((query (+ term
@@ -1506,7 +1511,7 @@ Multiple predicates are combined with BOOLEAN."
                                      positive-term))
                            (positive-term (or (and predicate-with-args `(pred args -- (cons (intern pred) args)))
                                               (and predicate-without-args `(pred -- (list (intern pred))))
-                                              (and plain-string `(s -- (list 'regexp s)))))
+                                              (and plain-string `(s -- (list org-ql-default-predicate s)))))
                            (plain-string (or quoted-arg unquoted-arg))
                            (predicate-with-args (substring predicate) ":" args)
                            (predicate-without-args (substring predicate) ":")

--- a/org-ql.el
+++ b/org-ql.el
@@ -685,14 +685,14 @@ replace the clause with a preamble."
                                  ;; Only one regexp: match with preamble, then let predicate confirm (because
                                  ;; the match could be in e.g. the tags rather than the heading text).
                                  (setq org-ql-preamble (rx-to-string `(seq bol (1+ "*") (1+ blank) (0+ nonl)
-                                                                           ,regexp)
+                                                                           (regexp ,regexp))
                                                                      'no-group))
                                  element)
                                 (`(heading . ,regexps)
                                  ;; Multiple regexps: use preamble to match against first
                                  ;; regexp, then let the predicate match the rest.
                                  (setq org-ql-preamble (rx-to-string `(seq bol (1+ "*") (1+ blank) (0+ nonl)
-                                                                           ,(car regexps))
+                                                                           (regexp ,(car regexps)))
                                                                      'no-group))
                                  element)
 


### PR DESCRIPTION
1.  Search heading with complicate regexp is possibe: for example: "heading:[abc]+[def]+",  Fix #64
2. org-ql--plain-query: add default-predicate arg,  With this feature,  I can search headine by default, and get less and  precise cands
3. If search headine line fail, I can C-a and add r: to search regexp :-)


