### PR TITLE
confirmation message for org-ql-view-refresh

### DIFF
--- a/README.org
+++ b/README.org
@@ -388,6 +388,7 @@ Expands into a call to ~org-ql-select~ with the same arguments.  For convenience
      -  Alias =h= for =heading= predicate.
 +  Info manual.
 +  Function ~helm-org-ql-source~, which returns a Helm source that searches given buffers/files with ~helm-org-ql~.  It can be used for custom Helm commands that search certain files.
++  Display a message when views are refreshed.  (Thanks to [[https://github.com/xeijin][xeijin]].)
 
 *Fixed*
 +  Call =helm-make-source= directly instead of using =helm-build-sync-source= macro.  (Fixes [[https://github.com/alphapapa/org-ql/issues/60][#60]].  Thanks to [[https://github.com/matthuszagh][Matt Huszagh]] for reporting.)

--- a/org-ql-view.el
+++ b/org-ql-view.el
@@ -299,7 +299,10 @@ update search arguments."
     (goto-char (point-min))
     (or (when (search-forward current-line nil t)
           (beginning-of-line))
-        (goto-char old-pos))))
+        (goto-char old-pos))
+        (message "org-ql: view refreshed%s"
+                 (when org-ql-view-title
+                   (concat ": " (substring-no-properties org-ql-view-title))))))
 
 (defun org-ql-view-save ()
   "Save current `org-ql-search' buffer to `org-ql-views'."

--- a/org-ql-view.el
+++ b/org-ql-view.el
@@ -300,7 +300,7 @@ update search arguments."
     (or (when (search-forward current-line nil t)
           (beginning-of-line))
         (goto-char old-pos))
-        (message "org-ql: view refreshed")))
+    (message "View refreshed")))
 
 (defun org-ql-view-save ()
   "Save current `org-ql-search' buffer to `org-ql-views'."

--- a/org-ql-view.el
+++ b/org-ql-view.el
@@ -300,9 +300,7 @@ update search arguments."
     (or (when (search-forward current-line nil t)
           (beginning-of-line))
         (goto-char old-pos))
-        (message "org-ql: view refreshed%s"
-                 (when org-ql-view-title
-                   (concat ": " (substring-no-properties org-ql-view-title))))))
+        (message "org-ql: view refreshed")))
 
 (defun org-ql-view-save ()
   "Save current `org-ql-search' buffer to `org-ql-views'."


### PR DESCRIPTION
In keeping with behaviour of `org-agenda-redo` and associated commands when refreshing an `org-agenda` buffer. If nothing has changed in an `org-ql` buffer it can sometimes be difficult to determine if the refresh took place at all.