### PR TITLE
Add "parent" and "ancestors" predicates

### DIFF
--- a/README.org
+++ b/README.org
@@ -181,7 +181,9 @@ Arguments are listed next to predicate names, where applicable.
 
 +  =category (&optional categories)= :: Return non-nil if current heading is in one or more of ~CATEGORIES~ (a list of strings).
 +  =children (&optional query)= :: Return non-nil if current heading has direct child headings.  If ~QUERY~, test it against child headings.  This selector may be nested, e.g. to match grandchild headings.
++  =parent (&optional query)= :: Return non-nil if current heading has a direct parent heading.  If ~QUERY~, test it against the parent heading.  This selector may be nested, e.g. to match grandparent headings.
 +  =descendants (&optional query)= :: Return non-nil if current heading has descendant headings.  If ~QUERY~, test it against descendant headings.  This selector may be nested (if you can grok the nesting!).
++  =ancestors (&optional query)= :: Return non-nil if current heading has ancestor headings (which is true if it has a parent heading).  With ~QUERY~, return non-nil if some ancestor heading matches it. This selector may also be nested.
 +  =done= :: Return non-nil if entry's ~TODO~ keyword is in ~org-done-keywords~.
 +  =habit= :: Return non-nil if entry is a habit.
 +  =heading (&rest regexps)= :: Return non-nil if current entry's heading matches all ~REGEXPS~ (regexp strings).
@@ -395,6 +397,7 @@ Expands into a call to ~org-ql-select~ with the same arguments.  For convenience
      -  Negation of terms in plain queries using ~!~.  For example, ~tags:space !moon~ to exclude entries which contain ~moon~.
      -  Predicates =outline-path= (alias =olp=) and =outline-path-segment= (alias =olps=).
      -  Predicate ~src~, which matches Org Babel source blocks.
+     -  Predicates =parent= and =ancestors=.
      -  Alias =h= for =heading= predicate.
      -  Alias =r= for =regexp= predicate.  (Thanks to [[https://github.com/tumashu][Feng Shu]].)
 +  Info manual.

--- a/README.org
+++ b/README.org
@@ -404,7 +404,7 @@ Expands into a call to ~org-ql-select~ with the same arguments.  For convenience
      -  Negation of terms in plain queries using ~!~.  For example, ~tags:space !moon~ to exclude entries which contain ~moon~.
      -  Predicates =outline-path= (alias =olp=) and =outline-path-segment= (alias =olps=).
      -  Predicate ~src~, which matches Org Babel source blocks.
-     -  Predicates =parent= and =ancestors=.
+     -  Predicates =parent= and =ancestors=.  (Thanks to [[https://github.com/mm--][Josh Moller-Mara]].)
      -  Alias =h= for =heading= predicate.
      -  Alias =r= for =regexp= predicate.  (Thanks to [[https://github.com/tumashu][Feng Shu]].)
 +  Info manual.

--- a/README.org
+++ b/README.org
@@ -60,10 +60,17 @@ Installing with [[https://framagit.org/steckerhalter/quelpa][Quelpa]] is easy:
 #+END_SRC
 
 * Usage
+:PROPERTIES:
+:TOC:      :include descendants :depth 1
+:END:
 :CONTENTS:
--  [[#commands][Commands]]
--  [[#queries][Queries]]
--  [[#functions--macros][Functions / Macros]]
+- [[#commands][Commands]]
+- [[#queries][Queries]]
+  - [[#non-sexp-query-syntax][Non-sexp query syntax]]
+  - [[#general-predicates][General predicates]]
+  - [[#ancestordescendant-predicates][Ancestor/descendant predicates]]
+  - [[#datetime-predicates][Date/time predicates]]
+- [[#functions--macros][Functions / Macros]]
 :END:
 
 # These links work on GitHub's Org renderer but not in Org.

--- a/README.org
+++ b/README.org
@@ -143,10 +143,14 @@ Show a sparse tree for ~QUERY~ in ~BUFFER~ and return number of results.  The tr
 ~QUERY~ is an ~org-ql~ query sexp (quoted, since this is a function).  ~BUFFER~ defaults to the current buffer.  When ~KEEP-PREVIOUS~ is non-nil (interactively, with prefix), the outline is not reset to the overview state before finding matches, which allows stacking calls to this command.  Runs ~org-occur-hook~ after making the sparse tree.
 
 ** Queries
+:PROPERTIES:
+:TOC:      :include descendants :depth 1
+:END:
 :CONTENTS:
--  [[#non-sexp-query-syntax][Non-sexp query syntax]]
--  [[#predicates][Predicates]]
--  [[#datetime-predicates][Date/time predicates]]
+- [[#non-sexp-query-syntax][Non-sexp query syntax]]
+- [[#general-predicates][General predicates]]
+- [[#ancestordescendant-predicates][Ancestor/descendant predicates]]
+- [[#datetime-predicates][Date/time predicates]]
 :END:
 
 An =org-ql= query is a lisp form which may contain arbitrary lisp forms, as well as certain built-in predicates.  It is byte-compiled into a predicate function which is tested with point on each heading in an Org buffer; when it returns non-nil, the heading matches the query.
@@ -175,15 +179,11 @@ The command =org-ql-search= also accepts, and the command =helm-org-ql= only acc
 
 Note that the =priority= predicate does not support comparators in the non-sexp syntax, so multiple priorities should be passed instead, as seen in the last example.
 
-*** Predicates
+*** General predicates
 
 Arguments are listed next to predicate names, where applicable.
 
 +  =category (&optional categories)= :: Return non-nil if current heading is in one or more of ~CATEGORIES~ (a list of strings).
-+  =children (&optional query)= :: Return non-nil if current heading has direct child headings.  If ~QUERY~, test it against child headings.  This selector may be nested, e.g. to match grandchild headings.
-+  =parent (&optional query)= :: Return non-nil if current heading has a direct parent heading.  If ~QUERY~, test it against the parent heading.  This selector may be nested, e.g. to match grandparent headings.
-+  =descendants (&optional query)= :: Return non-nil if current heading has descendant headings.  If ~QUERY~, test it against descendant headings.  This selector may be nested (if you can grok the nesting!).
-+  =ancestors (&optional query)= :: Return non-nil if current heading has ancestor headings (which is true if it has a parent heading).  With ~QUERY~, return non-nil if some ancestor heading matches it. This selector may also be nested.
 +  =done= :: Return non-nil if entry's ~TODO~ keyword is in ~org-done-keywords~.
 +  =habit= :: Return non-nil if entry is a habit.
 +  =heading (&rest regexps)= :: Return non-nil if current entry's heading matches all ~REGEXPS~ (regexp strings).
@@ -207,6 +207,13 @@ Arguments are listed next to predicate names, where applicable.
 +  =tags-all (tags)= :: Return non-nil if current heading includes all of ~TAGS~.  Tests both inherited and local tags.
      -  Aliases: ~tags&~.
 +  =todo (&optional keywords)= :: Return non-nil if current heading is a ~TODO~ item.  With ~KEYWORDS~, return non-nil if its keyword is one of ~KEYWORDS~ (a list of strings).  When called without arguments, only matches non-done tasks (i.e. does not match keywords in ~org-done-keywords~).
+
+*** Ancestor/descendant predicates
+
++  =ancestors (&optional query)= :: Return non-nil if current heading has ancestor headings.  If ~QUERY~, return non-nil if an ancestor heading matches it.  This selector may be nested.
++  =children (&optional query)= :: Return non-nil if current heading has direct child headings.  If ~QUERY~, return non-nil if a child heading matches it.  This selector may be nested, e.g. to match grandchild headings.
++  =descendants (&optional query)= :: Return non-nil if current heading has descendant headings.  If ~QUERY~, return non-nil if a descendant heading matches it.  This selector may be nested (if you can grok the nesting!).
++  =parent (&optional query)= :: Return non-nil if current heading has a direct parent heading.  If ~QUERY~, return non-nil if the parent heading matches it.  This selector may be nested, e.g. to match grandparent headings.
 
 *** Date/time predicates
 

--- a/README.org
+++ b/README.org
@@ -420,6 +420,7 @@ Expands into a call to ~org-ql-select~ with the same arguments.  For convenience
 +  Respect Org Agenda restriction in =org-ql-block=.  (Thanks to [[https://github.com/yantar92][Ihor Radchenko]] for reporting.)
 +  Option =org-ql-view-sidebar-sort-views=.
 +  Mouseover =help-echo= text for =org-ql-views= default view names.
++  "Dangling tasks" default view in =org-ql-views=.  (Users who have modified =org-ql-views= from the default will not see the new view unless they copy it into their config.)
 
 *Changed*
 +  Some default =org-ql-view= views (users who have modified =org-ql-views= from the default will not see the new views unless they copy them into their config):

--- a/examples.org
+++ b/examples.org
@@ -2,17 +2,20 @@
 
 * Contents
 :PROPERTIES:
-:TOC:      this
+:TOC:      :include siblings :ignore this
 :END:
-  -  [[#agenda-like-view][Agenda-like view]]
-  -  [[#entries-from-the-past-week][Entries from the past week]]
-  -  [[#find-entries-matching-a-certain-custom_id][Find entries matching a certain CUSTOM_ID]]
-  -  [[#listing-bills-coming-due][Listing bills coming due]]
-  -  [[#music-database][Music database]]
-  -  [[#return-org-elements][Return Org elements]]
-  -  [[#set-tags-on-certain-entries][Set tags on certain entries]]
-  -  [[#show-entries-with-recent-timestamps][Show entries with recent timestamps]]
-  -  [[#stuck-projects-block-agenda][Stuck projects block agenda]]
+:CONTENTS:
+- [[#agenda-like-view][Agenda-like view]]
+- [[#entries-from-the-past-week][Entries from the past week]]
+- [[#find-entries-matching-a-certain-custom_id][Find entries matching a certain CUSTOM_ID]]
+- [[#listing-bills-coming-due][Listing bills coming due]]
+- [[#music-database][Music database]]
+- [[#return-org-elements][Return Org elements]]
+- [[#set-tags-on-certain-entries][Set tags on certain entries]]
+- [[#show-entries-with-recent-timestamps][Show entries with recent timestamps]]
+- [[#stuck-projects-block-agenda][Stuck projects block agenda]]
+- [[#subproject-and-subtask-queries][Subproject and subtask queries]]
+:END:
 
 * Agenda-like view
 
@@ -173,9 +176,67 @@ With this =org-ql-block= agenda view, like:
                           ((org-ql-block-header "Stuck Projects")))))))
 #+END_SRC
 
+* Subproject and subtask queries
+
+#+BEGIN_SRC elisp
+  ;; Search for subprojects.
+  (org-ql-search (org-agenda-files)
+    '(and (todo "PROJECT")
+          (ancestors (todo "PROJECT"))))
+
+  ;; Search for all subtasks of projects, grouped by parent heading.
+  (org-ql-search (org-agenda-files)
+    '(and (todo)
+          (ancestors (todo "PROJECT")))
+    :super-groups '((:auto-parent t)))
+
+  ;; Search for direct top-level tasks of projects.
+  (org-ql-search (org-agenda-files)
+    '(and (todo)
+          (parent (todo "PROJECT")))
+    :super-groups '((:auto-parent t)))
+#+END_SRC
+
+Of course, all of those presume using a =PROJECT= keyword to define projects. If one defines a project as any task which has an ancestor task, one could use queries like:
+
+#+BEGIN_SRC elisp
+  ;; Search for all subtasks of top-level projects, grouped by parent heading.
+  (org-ql-search (org-agenda-files)
+    '(and (todo)
+          (ancestors
+           (and (todo)
+                (not (parent)))))
+    :super-groups '((:auto-parent t)))
+
+  ;; Search for all subtasks of all projects, including subprojects, grouped by project.
+  (org-ql-search (org-agenda-files)
+    '(and (todo)
+          (ancestors (todo)))
+    :super-groups '((:auto-parent t)))
+#+END_SRC
+
+Other interesting queries:
+
+#+BEGIN_SRC elisp
+  ;; Subtasks of upcoming deadline items.
+  (org-ql-search (org-agenda-files)
+    '(and (todo)
+          (ancestors
+           (and (not (done))
+                (deadline auto))))
+    :super-groups '((:auto-parent t)))
+
+  ;; TODO items whose ancestor is already DONE, and should therefore be
+  ;; either marked DONE or CANCELLED.
+  (org-ql-search (org-agenda-files)
+    '(and (todo)
+          (ancestors (done)))
+    :super-groups '((:auto-parent t)))
+#+END_SRC
+
 * COMMENT Code                                                     :noexport:
 :PROPERTIES:
-:TOC:      ignore
+:TOC:      :ignore (this descendants)
 :END:
 
 ** File-local variables

--- a/org-ql-view.el
+++ b/org-ql-view.el
@@ -177,6 +177,15 @@ See info node `(elisp)Cyclic Window Ordering'."
                     :super-groups 'org-super-agenda-groups
                     :sort '(priority)))))
         (cons "Review: Recently timestamped" #'org-ql-view-recent-items)
+        (cons (propertize "Review: Dangling tasks"
+                          'help-echo "Tasks whose ancestor is done")
+              (list :buffers-files #'org-agenda-files
+                    :query '(and (todo)
+                                 (ancestors (done)))
+                    :title (propertize "Review: Dangling tasks"
+                                       'help-echo "Tasks whose ancestor is done")
+                    :sort '(date priority todo)
+                    :super-groups '((:auto-parent t))))
         (cons (propertize "Review: Stale tasks"
                           'help-echo "Tasks without a timestamp in the past 2 weeks")
               (list :buffers-files #'org-agenda-files

--- a/org-ql.el
+++ b/org-ql.el
@@ -933,57 +933,6 @@ Arguments STRING, POS, FILL, and LEVEL are according to
 
 ;;;;; Predicates
 
-(org-ql--defpred children (query)
-  "Return non-nil if current entry has children matching QUERY."
-  (org-with-wide-buffer
-   ;; Widening is needed if inside an "ancestors" query
-   (org-narrow-to-subtree)
-   (when (org-goto-first-child)
-     ;; Lisp makes this easy and elegant: all we do is modify the query,
-     ;; nesting it inside an (and), and it doesn't descend into grandchildren.
-
-     ;; TODO: However, this could probably be rewritten like the `ancestors' predicate,
-     ;; which avoids calling `org-ql-select' recursively and its associated overhead.
-     (let* ((level (org-current-level))
-            (query (cl-typecase query
-                     (byte-code-function `(and (level ,level)
-                                               (funcall ,query)))
-                     (t `(and (level ,level)
-                              ,query)))))
-       (catch 'found
-         (org-ql-select (current-buffer)
-           query
-           :narrow t
-           :action (lambda ()
-                     (throw 'found t))))))))
-
-(org-ql--defpred parent (predicate)
-  "Return non-nil if the current entry's parent satisfies PREDICATE."
-  (org-with-wide-buffer
-   (when (org-up-heading-safe)
-     (org-ql--value-at (point) predicate))))
-
-(org-ql--defpred descendants (query)
-  "Return non-nil if current entry has descendants matching QUERY."
-  ;; TODO: This could probably be rewritten like the `ancestors' predicate,
-  ;; which avoids calling `org-ql-select' recursively and its associated overhead.
-  (org-with-wide-buffer
-    (org-narrow-to-subtree)
-    (when (org-goto-first-child)
-      (narrow-to-region (point) (point-max))
-      (catch 'found
-        (org-ql-select (current-buffer)
-          query
-          :narrow t
-          :action (lambda ()
-                    (throw 'found t)))))))
-
-(org-ql--defpred ancestors (predicate)
-  "Return non-nil if any of current entry's ancestors satisfy PREDICATE."
-  (org-with-wide-buffer
-   (cl-loop while (org-up-heading-safe)
-            thereis (org-ql--value-at (point) predicate))))
-
 (org-ql--defpred category (&rest categories)
   "Return non-nil if current heading is in one or more of CATEGORIES (a list of strings)."
   (when-let ((category (org-get-category (point))))
@@ -1212,6 +1161,74 @@ language."
                          always (re-search-forward re contents-end t)))
             ;; No regexps to check: return non-nil.
             t))))))
+
+;;;;;; Ancestor/descendant
+
+;; These predicates search ancestor and descendant headings for sub-queries.
+
+;; Note that the implementations of the upward-searching, ancestor/parent predicates differ
+;; from that of the downward-searching, descendants/children predicates in that the former
+;; take a predicate function as their argument and test it on each heading (the predicate
+;; being created by the `--query-pre-process' function, which see), while the latter take an
+;; `org-ql' query form as their argument and execute another `org-ql-select' query inside of
+;; the currently running query.  This "split" implementation seems like the most generally
+;; efficient one, because searching descendants searches potentially many more headings than
+;; searching ancestors, so executing a full query in that case can be faster due to use of
+;; the "preambles" provided by running a full query.  However, see note below.
+
+(org-ql--defpred parent (predicate)
+  "Return non-nil if the current entry's parent satisfies PREDICATE."
+  (org-with-wide-buffer
+   (when (org-up-heading-safe)
+     (org-ql--value-at (point) predicate))))
+
+(org-ql--defpred ancestors (predicate)
+  "Return non-nil if any of current entry's ancestors satisfy PREDICATE."
+  (org-with-wide-buffer
+   (cl-loop while (org-up-heading-safe)
+            thereis (org-ql--value-at (point) predicate))))
+
+;; MAYBE: The `children' and `descendants' predicates could probably be rewritten like
+;; the `ancestors' predicate, which avoids calling `org-ql-select' recursively and its
+;; associated overhead.  However, that would preclude the use of preambles, so depending
+;; on the Org file being searched and the sub-query, performance could be better or
+;; worse.  It should be benchmarked extensively before so changing the implementation.
+
+(org-ql--defpred children (query)
+  "Return non-nil if current entry has children matching QUERY."
+  (org-with-wide-buffer
+   ;; Widening is needed if inside an "ancestors" query
+   (org-narrow-to-subtree)
+   (when (org-goto-first-child)
+     ;; Lisp makes this easy and elegant: all we do is modify the query,
+     ;; nesting it inside an (and), and it doesn't descend into grandchildren.
+     (let* ((level (org-current-level))
+            (query (cl-typecase query
+                     (byte-code-function `(and (level ,level)
+                                               (funcall ,query)))
+                     (t `(and (level ,level)
+                              ,query)))))
+       (catch 'found
+         (org-ql-select (current-buffer)
+           query
+           :narrow t
+           :action (lambda ()
+                     (throw 'found t))))))))
+
+(org-ql--defpred descendants (query)
+  "Return non-nil if current entry has descendants matching QUERY."
+  ;; TODO: This could probably be rewritten like the `ancestors' predicate,
+  ;; which avoids calling `org-ql-select' recursively and its associated overhead.
+  (org-with-wide-buffer
+   (org-narrow-to-subtree)
+   (when (org-goto-first-child)
+     (narrow-to-region (point) (point-max))
+     (catch 'found
+       (org-ql-select (current-buffer)
+         query
+         :narrow t
+         :action (lambda ()
+                   (throw 'found t)))))))
 
 ;;;;;; Timestamps
 

--- a/org-ql.el
+++ b/org-ql.el
@@ -941,6 +941,9 @@ Arguments STRING, POS, FILL, and LEVEL are according to
    (when (org-goto-first-child)
      ;; Lisp makes this easy and elegant: all we do is modify the query,
      ;; nesting it inside an (and), and it doesn't descend into grandchildren.
+
+     ;; TODO: However, this could probably be rewritten like the `ancestors' predicate,
+     ;; which avoids calling `org-ql-select' recursively and its associated overhead.
      (let* ((level (org-current-level))
             (query (cl-typecase query
                      (byte-code-function `(and (level ,level)
@@ -962,6 +965,8 @@ Arguments STRING, POS, FILL, and LEVEL are according to
 
 (org-ql--defpred descendants (query)
   "Return non-nil if current entry has descendants matching QUERY."
+  ;; TODO: This could probably be rewritten like the `ancestors' predicate,
+  ;; which avoids calling `org-ql-select' recursively and its associated overhead.
   (org-with-wide-buffer
     (org-narrow-to-subtree)
     (when (org-goto-first-child)

--- a/org-ql.el
+++ b/org-ql.el
@@ -1169,24 +1169,28 @@ language."
 ;; Note that the implementations of the upward-searching, ancestor/parent predicates differ
 ;; from that of the downward-searching, descendants/children predicates in that the former
 ;; take a predicate function as their argument and test it on each heading (the predicate
-;; being created by the `--query-pre-process' function, which see), while the latter take an
+;; being created by the `--pre-process-query' function, which see), while the latter take an
 ;; `org-ql' query form as their argument and execute another `org-ql-select' query inside of
 ;; the currently running query.  This "split" implementation seems like the most generally
 ;; efficient one, because searching descendants searches potentially many more headings than
 ;; searching ancestors, so executing a full query in that case can be faster due to use of
 ;; the "preambles" provided by running a full query.  However, see note below.
 
-(org-ql--defpred parent (predicate)
-  "Return non-nil if the current entry's parent satisfies PREDICATE."
-  (org-with-wide-buffer
-   (when (org-up-heading-safe)
-     (org-ql--value-at (point) predicate))))
+;; NOTE: The ancestors and parent predicates' docstrings are developer-facing
+;; rather than user-facing, since their arguments are predicates provided
+;; automatically by `--pre-process-query'.
 
 (org-ql--defpred ancestors (predicate)
   "Return non-nil if any of current entry's ancestors satisfy PREDICATE."
   (org-with-wide-buffer
    (cl-loop while (org-up-heading-safe)
             thereis (org-ql--value-at (point) predicate))))
+
+(org-ql--defpred parent (predicate)
+  "Return non-nil if the current entry's parent satisfies PREDICATE."
+  (org-with-wide-buffer
+   (when (org-up-heading-safe)
+     (org-ql--value-at (point) predicate))))
 
 ;; MAYBE: The `children' and `descendants' predicates could probably be rewritten like
 ;; the `ancestors' predicate, which avoids calling `org-ql-select' recursively and its

--- a/org-ql.el
+++ b/org-ql.el
@@ -549,9 +549,9 @@ Replaces bare strings with (regexp) selectors, and appropriate
                      (`(descendants ,query) `(descendants ',query))
                      (`(descendants) '(descendants (lambda () t)))
                      (`(parent ,query) `(parent ,(org-ql--query-predicate (rec query))))
-                     (`(parent) `(parent ,(org-ql--query-predicate (rec '(lambda () t)))))
+                     (`(parent) '(parent (lambda () t)))
                      (`(ancestors ,query) `(ancestors ,(org-ql--query-predicate (rec query))))
-                     (`(ancestors) `(ancestors ,(org-ql--query-predicate (rec '(lambda () t)))))
+                     (`(ancestors) '(ancestors (lambda () t)))
                      ;; Timestamp-based predicates.  I think this is the way that makes the most sense:
                      ;; set the limit to N days in the future, adjusted to 23:59:59 (since Org doesn't
                      ;; support timestamps down to the second, anyway, there should be no need to adjust

--- a/org-ql.info
+++ b/org-ql.info
@@ -755,6 +755,9 @@ will be pushed to the master branch when ready.
      Radchenko (https://github.com/yantar92) for reporting.)
    • Option org-ql-view-sidebar-sort-views.
    • Mouseover help-echo text for org-ql-views default view names.
+   • "Dangling tasks" default view in org-ql-views.  (Users who have
+     modified org-ql-views from the default will not see the new view
+     unless they copy it into their config.)
 
    *Changed*
    • Some default org-ql-view views (users who have modified
@@ -1079,18 +1082,18 @@ Node: Agenda-like views18941
 Node: Listing / acting-on results20346
 Node: Changelog24948
 Node: 04-pre25485
-Node: 03229219
-Node: 03129600
-Node: 0329795
-Node: 02332768
-Node: 02232994
-Node: 02133260
-Node: 0233457
-Node: 0137490
-Node: Notes37589
-Node: Comparison with Org Agenda searches37751
-Node: org-sidebar38622
-Node: License38901
+Node: 03229405
+Node: 03129786
+Node: 0329981
+Node: 02332954
+Node: 02233180
+Node: 02133446
+Node: 0233643
+Node: 0137676
+Node: Notes37775
+Node: Comparison with Org Agenda searches37937
+Node: org-sidebar38808
+Node: License39087
 
 End Tag Table
 

--- a/org-ql.info
+++ b/org-ql.info
@@ -50,7 +50,8 @@ Commands
 Queries
 
 * Non-sexp query syntax::
-* Predicates::
+* General predicates::
+* Ancestor/descendant predicates::
 * Date/time predicates::
 
 
@@ -146,7 +147,8 @@ File: README.info,  Node: Usage,  Next: Changelog,  Prev: Installation,  Up: Top
 4 Usage
 *******
 
-   • • • 
+   • • 
+        • • • • • 
    Feedback on these APIs is welcome.  Eventually, after being tested
 and polished, they will be considered stable.
 
@@ -294,7 +296,7 @@ File: README.info,  Node: Queries,  Next: Functions / Macros,  Prev: Commands,  
 4.2 Queries
 ===========
 
-   • • • 
+   • • • • 
    An org-ql query is a lisp form which may contain arbitrary lisp
 forms, as well as certain built-in predicates.  It is byte-compiled into
 a predicate function which is tested with point on each heading in an
@@ -311,11 +313,12 @@ Org buffer; when it returns non-nil, the heading matches the query.
 * Menu:
 
 * Non-sexp query syntax::
-* Predicates::
+* General predicates::
+* Ancestor/descendant predicates::
 * Date/time predicates::
 
 
-File: README.info,  Node: Non-sexp query syntax,  Next: Predicates,  Up: Queries
+File: README.info,  Node: Non-sexp query syntax,  Next: General predicates,  Up: Queries
 
 4.2.1 Non-sexp query syntax
 ---------------------------
@@ -345,24 +348,16 @@ non-sexp syntax, so multiple priorities should be passed instead, as
 seen in the last example.
 
 
-File: README.info,  Node: Predicates,  Next: Date/time predicates,  Prev: Non-sexp query syntax,  Up: Queries
+File: README.info,  Node: General predicates,  Next: Ancestor/descendant predicates,  Prev: Non-sexp query syntax,  Up: Queries
 
-4.2.2 Predicates
-----------------
+4.2.2 General predicates
+------------------------
 
 Arguments are listed next to predicate names, where applicable.
 
 ‘category (&optional categories)’
      Return non-nil if current heading is in one or more of ‘CATEGORIES’
      (a list of strings).
-‘children (&optional query)’
-     Return non-nil if current heading has direct child headings.  If
-     ‘QUERY’, test it against child headings.  This selector may be
-     nested, e.g.  to match grandchild headings.
-‘descendants (&optional query)’
-     Return non-nil if current heading has descendant headings.  If
-     ‘QUERY’, test it against descendant headings.  This selector may be
-     nested (if you can grok the nesting!).
 ‘done’
      Return non-nil if entry’s ‘TODO’ keyword is in ‘org-done-keywords’.
 ‘habit’
@@ -444,9 +439,32 @@ Arguments are listed next to predicate names, where applicable.
      ‘org-done-keywords’).
 
 
-File: README.info,  Node: Date/time predicates,  Prev: Predicates,  Up: Queries
+File: README.info,  Node: Ancestor/descendant predicates,  Next: Date/time predicates,  Prev: General predicates,  Up: Queries
 
-4.2.3 Date/time predicates
+4.2.3 Ancestor/descendant predicates
+------------------------------------
+
+‘ancestors (&optional query)’
+     Return non-nil if current heading has ancestor headings.  If
+     ‘QUERY’, return non-nil if an ancestor heading matches it.  This
+     selector may be nested.
+‘children (&optional query)’
+     Return non-nil if current heading has direct child headings.  If
+     ‘QUERY’, return non-nil if a child heading matches it.  This
+     selector may be nested, e.g.  to match grandchild headings.
+‘descendants (&optional query)’
+     Return non-nil if current heading has descendant headings.  If
+     ‘QUERY’, return non-nil if a descendant heading matches it.  This
+     selector may be nested (if you can grok the nesting!).
+‘parent (&optional query)’
+     Return non-nil if current heading has a direct parent heading.  If
+     ‘QUERY’, return non-nil if the parent heading matches it.  This
+     selector may be nested, e.g.  to match grandparent headings.
+
+
+File: README.info,  Node: Date/time predicates,  Prev: Ancestor/descendant predicates,  Up: Queries
+
+4.2.4 Date/time predicates
 --------------------------
 
 All of these predicates take optional keyword arguments ‘:from’, ‘:to:’,
@@ -722,6 +740,8 @@ will be pushed to the master branch when ready.
         • Predicates outline-path (alias olp) and outline-path-segment
           (alias olps).
         • Predicate ‘src’, which matches Org Babel source blocks.
+        • Predicates parent and ancestors.  (Thanks to Josh Moller-Mara
+          (https://github.com/mm--).)
         • Alias h for heading predicate.
         • Alias r for regexp predicate.  (Thanks to Feng Shu
           (https://github.com/tumashu).)
@@ -1037,39 +1057,40 @@ GPLv3
 
 Tag Table:
 Node: Top225
-Node: Contents1367
-Node: Screenshots1541
-Node: Installation1659
-Node: Quelpa2297
-Node: Usage2740
-Node: Commands3064
-Node: org-ql-search3537
-Node: helm-org-ql5185
-Node: org-ql-view5597
-Node: org-ql-view-sidebar5795
-Node: org-ql-view-recent-items6151
-Node: org-ql-sparse-tree6635
-Node: Queries7435
-Node: Non-sexp query syntax8296
-Node: Predicates9995
-Node: Date/time predicates15217
-Node: Functions / Macros17852
-Node: Agenda-like views18085
-Node: Listing / acting-on results19490
-Node: Changelog24092
-Node: 04-pre24629
-Node: 03228251
-Node: 03128632
-Node: 0328827
-Node: 02331800
-Node: 02232026
-Node: 02132292
-Node: 0232489
-Node: 0136522
-Node: Notes36621
-Node: Comparison with Org Agenda searches36783
-Node: org-sidebar37654
-Node: License37933
+Node: Contents1410
+Node: Screenshots1584
+Node: Installation1702
+Node: Quelpa2340
+Node: Usage2783
+Node: Commands3132
+Node: org-ql-search3605
+Node: helm-org-ql5253
+Node: org-ql-view5665
+Node: org-ql-view-sidebar5863
+Node: org-ql-view-recent-items6219
+Node: org-ql-sparse-tree6703
+Node: Queries7503
+Node: Non-sexp query syntax8411
+Node: General predicates10118
+Node: Ancestor/descendant predicates14925
+Node: Date/time predicates16053
+Node: Functions / Macros18708
+Node: Agenda-like views18941
+Node: Listing / acting-on results20346
+Node: Changelog24948
+Node: 04-pre25485
+Node: 03229219
+Node: 03129600
+Node: 0329795
+Node: 02332768
+Node: 02232994
+Node: 02133260
+Node: 0233457
+Node: 0137490
+Node: Notes37589
+Node: Comparison with Org Agenda searches37751
+Node: org-sidebar38622
+Node: License38901
 
 End Tag Table
 

--- a/tests/test-org-ql.el
+++ b/tests/test-org-ql.el
@@ -347,6 +347,24 @@ RESULTS should be a list of strings as returned by
 
     ;; TODO: Other predicates.
 
+    (describe "(ancestors)"
+      (org-ql-it "without sub-query"
+        (org-ql-expect ((ancestors))
+          '("Take over the world" "Skype with president of Antarctica" "Take over Mars" "Visit Mars" "Take over the moon" "Visit the moon" "Practice leaping tall buildings in a single bound" "Renew membership in supervillain club" "Learn universal sign language" "/r/emacs" "Shop for groceries" "Sunrise/sunset" "Rewrite Emacs in Common Lisp" "Write a symphony")))
+
+      (org-ql-it "with sub-query"
+        (org-ql-expect ((ancestors (heading "universe")))
+          '("Take over the world" "Skype with president of Antarctica" "Take over Mars" "Visit Mars" "Take over the moon" "Visit the moon" "Practice leaping tall buildings in a single bound" "Renew membership in supervillain club" "Learn universal sign language"))))
+
+    (describe "(parent)"
+      (org-ql-it "without sub-query"
+        (org-ql-expect ((parent))
+          '("Take over the world" "Skype with president of Antarctica" "Take over Mars" "Visit Mars" "Take over the moon" "Visit the moon" "Practice leaping tall buildings in a single bound" "Renew membership in supervillain club" "Learn universal sign language" "/r/emacs" "Shop for groceries" "Sunrise/sunset" "Rewrite Emacs in Common Lisp" "Write a symphony")))
+
+      (org-ql-it "with sub-query"
+        (org-ql-expect ((parent (and (todo) (priority "A"))))
+          '("Take over the world" "Skype with president of Antarctica" "Take over Mars" "Take over the moon" "Practice leaping tall buildings in a single bound" "Renew membership in supervillain club" "Learn universal sign language"))))
+
     (describe "(category)"
 
       (org-ql-it "without arguments"


### PR DESCRIPTION
Hi!

First of all, terrific package! Not only does `org-ql`'s clean sexp syntax make it quick an easy to write sophisticated agenda views (whereas before you had to write complicated "skip functions"), the query caching makes rebuilding agendas super fast! I think you've saved me from declaring org-mode bankruptcy. :P

I noticed the `children` and `descendants` predicates didn't seem to have analog `parent` and `ancestors` predicates. So I wrote those, and then later realized you had a WIP branch. D'oh.

Anyway, I think having `parent` and `ancestors` predicates would be super helpful.

For example, I use a non-inherited "project" tag (in `org-tags-exclude-from-inheritance`) to denote projects (so I can't use the workaround in #21). With "ancestors", I can write the following query to find unscheduled "NEXT" items in stuck projects:

```elisp
(org-ql-search (org-agenda-files)
  '(and (todo "NEXT")
	(not (scheduled))
	(ancestors (and (tags-local "project")
			(not (descendants (and (todo)
					       (scheduled)))))))
  :title "Next tasks that should be scheduled")
```

I haven't extensively profiled `ancestors`. You mentioned in your branch that there may be some performance concerns, especially since the query inside of `ancestors` might be tested on siblings (those this is limited with `level`, it seems like it might traverse all siblings [I'm not sure]). But it seems pretty usable to me for now.

I've also added some documentation for the predicates. I haven't included the updated `org-ql.info`, as my version of `makeinfo` seems to be giving different formatting.