### PR TITLE
Fix org-ql--value-at returning org-ql-nil during cache miss

### DIFF
--- a/org-ql.el
+++ b/org-ql.el
@@ -477,7 +477,9 @@ Values compared with `equal'."
                  org-ql-node-value-cache))
       (map-put value-cache fn new-value)
       (puthash position value-cache position-cache)
-      new-value)))
+      (pcase new-value
+        ('org-ql-nil nil)
+        (_ new-value)))))
 
 (defun org-ql--add-markers (element)
   "Return ELEMENT with Org marker text properties added.


### PR DESCRIPTION
`org-ql--value-at` improperly returned `'org-ql-nil` when `fn` returns
`nil` during a cache miss. All following calls to `org-ql--value-at`,
however, would properly return `nil`.

This fixes the issue with the cache miss, so the first call also returns `nil`.

This was mentioned in #77, but split out here for clarity, as suggested.

Thanks!
-Josh