### PR TITLE
Fix: set face for org-done-keywords correctly

### DIFF
--- a/README.org
+++ b/README.org
@@ -394,6 +394,7 @@ Expands into a call to ~org-ql-select~ with the same arguments.  For convenience
 *Fixed*
 +  Call =helm-make-source= directly instead of using =helm-build-sync-source= macro.  (Fixes [[https://github.com/alphapapa/org-ql/issues/60][#60]].  Thanks to [[https://github.com/matthuszagh][Matt Huszagh]] for reporting.)
 +  Search/view buffers now always end with a newline, which prevents side-scrolling of the window when calling =end-of-buffer=.
++  Face for done to-do keywords in =org-ql-view= buffers.  (Thanks to [[https://github.com/dsdshcym][Yiming Chen]].)
 
 *Internal*
 +  Added generic node data cache to speed up recursive, tree-based queries.

--- a/org-ql-view.el
+++ b/org-ql-view.el
@@ -634,7 +634,8 @@ property."
 
 (defun org-ql-view--add-todo-face (keyword)
   "Return KEYWORD with TODO face added."
-  (when-let ((face (org-get-todo-face keyword)))
+  (when-let* ((org-done-keywords org-done-keywords-for-agenda)
+              (face (org-get-todo-face keyword)))
     (org-add-props keyword nil 'face face)))
 
 ;;;; Footer

--- a/org-ql.info
+++ b/org-ql.info
@@ -729,6 +729,8 @@ File: README.info,  Node: 04-pre,  Next: 032,  Up: Changelog
      Huszagh (https://github.com/matthuszagh) for reporting.)
    • Search/view buffers now always end with a newline, which prevents
      side-scrolling of the window when calling end-of-buffer.
+   • Face for done to-do keywords in org-ql-view buffers.  (Thanks to
+     Yiming Chen (https://github.com/dsdshcym).)
 
    *Internal*
    • Added generic node data cache to speed up recursive, tree-based
@@ -1021,18 +1023,18 @@ Node: Agenda-like views18276
 Node: Listing / acting-on results19681
 Node: Changelog24283
 Node: 04-pre24820
-Node: 03226512
-Node: 03126893
-Node: 0327088
-Node: 02330061
-Node: 02230287
-Node: 02130553
-Node: 0230750
-Node: 0134783
-Node: Notes34882
-Node: Comparison with Org Agenda searches35044
-Node: org-sidebar35915
-Node: License36194
+Node: 03226633
+Node: 03127014
+Node: 0327209
+Node: 02330182
+Node: 02230408
+Node: 02130674
+Node: 0230871
+Node: 0134904
+Node: Notes35003
+Node: Comparison with Org Agenda searches35165
+Node: org-sidebar36036
+Node: License36315
 
 End Tag Table
 


### PR DESCRIPTION
- org-done-keywords is a buffer-local variable
- if we don't set it explicitly, org-get-todo-face would return nil for
  done keywords
- the same logic can be found at https://github.com/emacs-mirror/emacs/blob/9b6872b4e4fa782d9df313ab771c23ad1e7f8eff/lisp/org/org-agenda.el#L6980