### PR TITLE
Fix-example-org-wrong-command

### DIFF
--- a/examples.org
+++ b/examples.org
@@ -68,7 +68,7 @@ Show entries that have any timestamp within the past week.  Group by date using 
     '(ts :from -7 :to today)
     :title "Recent Items"
     :sort '(date priority todo)
-    :groups '((:auto-ts t)))
+    :super-groups '((:auto-ts t)))
 #+END_SRC
 
 * Find entries matching a certain =CUSTOM_ID=


### PR DESCRIPTION
**Error:**

`cond: Keyword argument :groups not one of (:narrow :super-groups :sort :title :buffer)`

I used the master branch also for `super-org-agenda`

Best Regards,
Enis
