### PR TITLE
Add: skip-subtrees option

### DIFF
--- a/org-ql-search.el
+++ b/org-ql-search.el
@@ -105,7 +105,7 @@ Runs `org-occur-hook' after making the sparse tree."
       num-results)))
 
 ;;;###autoload
-(cl-defun org-ql-search (buffers-files query &key narrow super-groups sort title
+(cl-defun org-ql-search (buffers-files query &key narrow super-groups sort title skip-subtrees
                                        (buffer org-ql-view-buffer))
   "Search for QUERY with `org-ql'.
 Interactively, prompt for these variables:
@@ -134,6 +134,8 @@ SORT: One or a list of `org-ql' sorting functions, like `date' or
 
 TITLE: An optional string displayed in the header.
 
+SKIP-SUBTREES: Skip subtrees in matching entries.
+
 BUFFER: Optionally, a buffer or name of a buffer in which to
 display the results.  By default, the value of
 `org-ql-view-buffer' is used, and a new buffer is created if
@@ -159,6 +161,7 @@ necessary."
                      (read-string "Query: " (when org-ql-view-query
                                               (format "%S" org-ql-view-query)))
                      :narrow (or org-ql-view-narrow (eq current-prefix-arg '(4)))
+                     :skip-subtrees (yes-or-no-p "Skip subtrees?")
                      :super-groups (when (bound-and-true-p org-super-agenda-auto-selector-keywords)
                                      (let ((keywords (cl-loop for type in org-super-agenda-auto-selector-keywords
                                                               collect (substring (symbol-name type) 6))))
@@ -200,7 +203,8 @@ necessary."
            (results (org-ql-select buffers-files query
                       :action 'element-with-markers
                       :narrow narrow
-                      :sort sort))
+                      :sort sort
+                      :skip-subtrees skip-subtrees))
            (strings (-map #'org-ql-view--format-element results))
            (buffer (or buffer (format "%s %s*" org-ql-view-buffer-name-prefix (or title query))))
            (header (org-ql-view--header-line-format buffers-files query title))

--- a/org-ql-view.el
+++ b/org-ql-view.el
@@ -87,6 +87,7 @@ Based on `org-agenda-mode-map'.")
 (defvar-local org-ql-view-query nil)
 (defvar-local org-ql-view-sort nil)
 (defvar-local org-ql-view-narrow nil)
+(defvar-local org-ql-view-skip-subtrees nil)
 (defvar-local org-ql-view-super-groups nil)
 (defvar-local org-ql-view-title nil)
 
@@ -218,12 +219,13 @@ Interactively, prompt for NAME."
       (select-window window))
     (cl-typecase view
       (function (call-interactively view))
-      (list (-let* (((&plist :buffers-files :query :sort :narrow :super-groups :title) view)
+      (list (-let* (((&plist :buffers-files :query :sort :narrow :super-groups :title :skip-subtrees) view)
                     (super-groups (cl-typecase super-groups
                                     (symbol (symbol-value super-groups))
                                     (list super-groups))))
               (org-ql-search buffers-files query
                 :super-groups super-groups :narrow narrow :sort sort :title title
+                :skip-subtrees skip-subtrees
                 :buffer org-ql-view-buffer))))))
 
 ;;;###autoload
@@ -287,6 +289,7 @@ update search arguments."
                          :sort org-ql-view-sort
                          :narrow org-ql-view-narrow
                          :super-groups org-ql-view-super-groups
+                         :skip-subtrees org-ql-view-skip-subtrees
                          :title org-ql-view-title))
          (org-ql-view-buffer (current-buffer)))
     (if prompt
@@ -309,6 +312,7 @@ update search arguments."
                       :query org-ql-view-query
                       :sort org-ql-view-sort
                       :narrow org-ql-view-narrow
+                      :skip-subtrees org-ql-view-skip-subtrees
                       :super-groups org-ql-view-super-groups
                       :title name)))
     (map-put org-ql-views name plist #'equal)


### PR DESCRIPTION
This implements an equivalent of `org-agenda-todo-list-sublevels` variable. 

I basically tweaked the loop in `org-ql--select` as follows and added `skip-subtrees` argument to functions and macros in this package:

``` emacs-lisp
(cond (preamble (let ((case-fold-search preamble-case-fold))
                  (cl-loop while (re-search-forward preamble nil t)
                           do (outline-back-to-heading 'invisible-ok)
                           when (funcall predicate)
                           collect (funcall action)
                           when skip-subtrees
                           do (org-end-of-subtree)
                           do (outline-next-heading))))
      (t (cl-loop when (funcall predicate)
                  collect (funcall action)
                  when skip-subtrees
                  do (org-end-of-subtree)
                  while (outline-next-heading))))
```

It seems to be working, but I am not sure if I am doing the right thing in the preamble case. How should I add test cases?