### PR TITLE
custom sorting function not reached

### DIFF
--- a/org-ql.el
+++ b/org-ql.el
@@ -242,7 +242,7 @@ returns nil or non-nil."
     (pcase sort
       (`nil items)
       ((or 'date 'deadline 'scheduled 'todo 'priority 'random
-           (guard (cl-loop for elem in sort
+           (guard (cl-loop for elem in (-list sort)
                            always (memq elem '(date deadline scheduled todo priority random)))))
        ;; Default sorting functions
        (org-ql--sort-by items (-list sort)))


### PR DESCRIPTION
I _think_ you need to ensure that sort is a list here; otherwise, `cl-loop' will always return true, the custom sorting function will not be called, and `org-ql--sort-by' will return an error. 