### PR TITLE
Change nreverse to non-destructive version

### DIFF
--- a/org-ql.el
+++ b/org-ql.el
@@ -1598,7 +1598,7 @@ PREDICATES is a list of one or more sorting methods, including:
                                                                              ;; Put at end of list if not found
                                                                              (1+ (length org-todo-keywords-1)))))))
                                      (-flatten-n 1 (-map #'cdr sorted-groups)))))
-    (cl-loop for pred in (nreverse predicates)
+    (cl-loop for pred in (reverse predicates)
              do (setq items (if (eq pred 'todo)
                                 (sort-by-todo-keyword items)
                               (-sort (sorter pred) items)))


### PR DESCRIPTION
I think this fixes #136 . I believe the issue stemmed from the fact that elisp lists are passed by reference, not value, so a destructive operation on a function parameter here changed the original list passed to `org-ql-search` up the stack.

If `nreverse` was desired behaviour here, I can try some other way of fixing the linked issue.