### PR TITLE
Changes in org-dblock-write:org-ql

### DIFF
--- a/README.org
+++ b/README.org
@@ -464,6 +464,7 @@ It would be expanded to:
 
 Org QL provides a dynamic block that lists entries in the current document matching a query.  In the header, these parameters are supported:
 
++  ~:file~: Any file that works in other org-ql queries, like `org-agenda-files'. Default value: current-buffer
 +  ~:query~: An Org QL query expression in either sexp or non-sexp form.
 +  ~:columns~ A list of columns, including ~heading~, ~todo~, ~property~, ~priority~, ~deadline~, ~scheduled~.
      -  Each column may also be specified as a list with the second element being a header string.  For example, to abbreviate the priority column: ~(priority "P")~.
@@ -479,7 +480,7 @@ For example, this dynamic block shows the first seven headings that are to-do it
 # NOTE: These results are edited manually because the Org links don't display well in the Info manual.
 
 #+BEGIN_SRC org
-  ,#+BEGIN: org-ql :query "todo: priority:A,B" :columns (todo (priority "P") ((property "agenda-group") "Group") deadline heading) :sort (deadline priority) :take 7 :ts-format "%Y-%m-%d %H:%M"
+  ,#+BEGIN: org-ql :query "todo: priority:A,B" :columns (todo (priority "P") ((property "agenda-group") "Group") deadline heading) :sort (deadline priority) :take 7 :ts-format "%Y-%m-%d %H:%M" :file org-agenda-files
   | Todo | P | Group | Deadline         | Heading                               |
   |------+---+-------+------------------+---------------------------------------|
   | TODO | A |       | 2017-07-07 00:00 | Take over the world                   |

--- a/org-ql-search.el
+++ b/org-ql-search.el
@@ -268,13 +268,15 @@ Valid parameters include:
             positive number) or the end (a negative number) of
             the results.
 
+  :link     set this to non-nil for org-links to be there. If you leave this out or to nil, then no links in the headings.
+
   :ts-format  Optional format string used to format
               timestamp-based columns.
 
 For example, an org-ql dynamic block header could look like:
 
-  #+BEGIN: org-ql :file org-agenda-files :query (todo \"UNDERWAY\") :columns (priority todo heading) :sort (priority date) :ts-format \"%Y-%m-%d %H:%M\""
-  (-let* (((&plist :query :columns :sort :ts-format :take :file) params)
+  #+BEGIN: org-ql :file org-agenda-files :query (todo \"UNDERWAY\") :columns (priority todo heading) :sort (priority date) :link t :ts-format \"%Y-%m-%d %H:%M\""
+  (-let* (((&plist :query :columns :sort :ts-format :take :link :file) params)
           (query (cl-etypecase query
                    (string (org-ql--query-string-to-sexp query))
                    (list  ;; SAFETY: Query is in sexp form: ask for confirmation, because it could contain arbitrary code.
@@ -289,22 +291,27 @@ For example, an org-ql dynamic block header could look like:
            (list (cons 'todo (lambda (element)
                                (org-element-property :todo-keyword element)))
                  (cons 'heading (lambda (element)
-                                  (org-link-make-string
-			                             (format "file:%s::%s"
-				                                   (marker-buffer (org-element-property :org-marker element))
-                                           (org-element-property :raw-value element))
-			                             ;; Prune statistics cookies.  Replace
-			                             ;; links with their description, or
-			                             ;; a plain link if there is none.
-			                             (org-trim
-			                              (org-link-display-format
-			                               (replace-regexp-in-string
-				                              "\\[[0-9]*\\(?:%\\|/[0-9]*\\)\\]" ""
-				                              (org-element-property :raw-value element)))))
-                                  ))
+		                              (--when-let (org-element-property :raw-value element)
+			                                   (if (not link) it
+			                                     (let ((search
+				                                          (org-link-heading-search-string it)))
+			                                       (org-link-make-string
+			                                        (format "file:%s::%s" (org-element-property :file element) search)
+			                                        ;; Prune statistics cookies.  Replace
+			                                        ;; links with their description, or
+			                                        ;; a plain link if there is none.
+			                                        (org-trim
+			                                         (org-link-display-format
+			                                          (replace-regexp-in-string
+				                                         "\\[[0-9]*\\(?:%\\|/[0-9]*\\)\\]" ""
+				                                         it))))
+                                             )))))
                  (cons 'priority (lambda (element)
                                    (--when-let (org-element-property :priority element)
                                      (char-to-string it))))
+                 (cons 'closed (lambda (element)
+                                   (--when-let (org-element-property :closed element)
+                                     (ts-format ts-format (ts-parse-org-element it)))))
                  (cons 'deadline (lambda (element)
                                    (--when-let (org-element-property :deadline element)
                                      (ts-format ts-format (ts-parse-org-element it)))))

--- a/org-ql.el
+++ b/org-ql.el
@@ -519,8 +519,10 @@ from within ELEMENT's buffer."
   ;; time?  I don't know, but for now, it seems that we have to use `copy-marker'.
   (let* ((marker (copy-marker (org-element-property :begin element)))
          (properties (--> (cadr element)
-                          (plist-put it :org-marker marker)
-                          (plist-put it :org-hd-marker marker))))
+                       (plist-put it :file buffer-file-name)
+                       (plist-put it :org-marker marker)
+                       (plist-put it :org-hd-marker marker)
+                       )))
     (setf (cadr element) properties)
     element))
 
@@ -611,7 +613,8 @@ respectively."
   (rx-to-string `(seq bol (group (zero-or-more (any "	 ")))
                       "#+begin_src"
                       (one-or-more (any "	 "))
-                      ,(or lang `(1+ (not (any "	\n\f "))))
+                      ,(or lang `(1+ (not (any "	\n\f
+ "))))
                       (zero-or-more (any "	 "))
                       (group (or (seq (zero-or-more (not (any "\n\":")))
                                       "\""
@@ -620,7 +623,7 @@ respectively."
                                       (zero-or-more (not (any "\n\":"))))
                                  (zero-or-more (not (any "\n\":")))))
                       (group (zero-or-more (not (any "\n")))) "\n"
-                      (63 (group (*\? (not (any " "))) "\n"))
+                      (63 (group (*\? (not (any ""))) "\n"))
                       (zero-or-more (any "	 "))
                       "#+end_src")
                 t))


### PR DESCRIPTION
Now org-agenda-files can be included as well as any other list of files that work for org-ql.

Useful if you are doing your weekly, quarterly or yearly reviews.

#151 is something that triggered my thoughts.