### PR TITLE
Add blocked predicate

### DIFF
--- a/README.org
+++ b/README.org
@@ -254,6 +254,7 @@ Arguments are listed next to predicate names, where applicable.
 +  =tags-regexp (&rest regexps)= :: Return non-nil if current heading has tags matching one or more of ~REGEXPS~.  Tests both inherited and local tags.
      -  Aliases: ~tags*~.
 +  =todo (&optional keywords)= :: Return non-nil if current heading is a ~TODO~ item.  With ~KEYWORDS~, return non-nil if its keyword is one of ~KEYWORDS~ (a list of strings).  When called without arguments, only matches non-done tasks (i.e. does not match keywords in ~org-done-keywords~).
++  =blocked= :: Return non-nil if current heading is blocked.
 
 *** Ancestor/descendant predicates
 

--- a/README.org
+++ b/README.org
@@ -221,6 +221,7 @@ Note that the =effort=, =level=, and =priority= predicates do not support compar
 
 Arguments are listed next to predicate names, where applicable.
 
++  =blocked= :: Return non-nil if current heading is blocked.  Calls ~org-entry-blocked-p~, which see.
 +  =category (&optional categories)= :: Return non-nil if current heading is in one or more of ~CATEGORIES~ (a list of strings).
 +  =done= :: Return non-nil if entry's ~TODO~ keyword is in ~org-done-keywords~.
 +  =effort (&optional effort-or-comparator effort)= :: Return non-nil if current heading's effort property matches arguments.  The following forms are accepted: ~(effort DURATION)~: Matches if effort is ~DURATION~.  ~(effort DURATION DURATION)~: Matches if effort is between DURATIONs, inclusive.  ~(effort COMPARATOR DURATION)~: Matches if effort compares to ~DURATION~ with ~COMPARATOR~.  ~COMPARATOR~ may be ~<~, ~<=~, ~>~, or ~>=~.  ~DURATION~ should be an Org effort string, like =5= or =0:05=.
@@ -254,7 +255,6 @@ Arguments are listed next to predicate names, where applicable.
 +  =tags-regexp (&rest regexps)= :: Return non-nil if current heading has tags matching one or more of ~REGEXPS~.  Tests both inherited and local tags.
      -  Aliases: ~tags*~.
 +  =todo (&optional keywords)= :: Return non-nil if current heading is a ~TODO~ item.  With ~KEYWORDS~, return non-nil if its keyword is one of ~KEYWORDS~ (a list of strings).  When called without arguments, only matches non-done tasks (i.e. does not match keywords in ~org-done-keywords~).
-+  =blocked= :: Return non-nil if current heading is blocked.
 
 *** Ancestor/descendant predicates
 
@@ -552,6 +552,7 @@ Simple links may also be written manually in either sexp or non-sexp form, like:
 +  Option ~org-ql-default-predicate~, applied to plain-string query tokens (before, the ~regexp~ predicate was always used, but now it may be customized).
 +  Alias ~c~ for predicate ~category~.
 +  Predicate ~property~ now accepts the argument ~:inherit~ to match entries with property inheritance, and when unspecified, the option ~org-use-property-inheritance~ controls whether inheritance is used.
++  Predicate ~blocked~.  (Thanks to [[https://github.com/akirak][Akira Komamura]].)
 
 *Changed*
 +  Give more useful error message for invalid queries.

--- a/org-ql.el
+++ b/org-ql.el
@@ -2377,6 +2377,11 @@ any planning prefix); it defaults to 0 (i.e. the whole regexp)."
             (from (test-timestamps (ts<= from next-ts)))
             (to (test-timestamps (ts<= next-ts to)))))))
 
+(org-ql-defpred blocked ()
+  "Return non-nil if the entry is blocked."
+  :body
+  (org-entry-blocked-p))
+
 ;; NOTE: Predicates defined: stop deferring and define normalizer and
 ;; preamble functions now.  Reversing preserves the order in which
 ;; they were defined.  Generally it shouldn't matter, but it might...

--- a/org-ql.el
+++ b/org-ql.el
@@ -1333,6 +1333,11 @@ result form."
 ;; redefinitions until all of the predicates have been defined.
 (setf org-ql-defpred-defer t)
 
+(org-ql-defpred blocked ()
+  "Return non-nil if entry is blocked.
+Calls `org-entry-blocked-p', which see."
+  :body (org-entry-blocked-p))
+
 (org-ql-defpred (category c) (&rest categories)
   "Return non-nil if current heading is in one or more of CATEGORIES."
   :normalizers ((`(,predicate-names . ,rest)
@@ -2376,11 +2381,6 @@ any planning prefix); it defaults to 0 (i.e. the whole regexp)."
             ((and from to) (test-timestamps (ts-in from to next-ts)))
             (from (test-timestamps (ts<= from next-ts)))
             (to (test-timestamps (ts<= next-ts to)))))))
-
-(org-ql-defpred blocked ()
-  "Return non-nil if the entry is blocked."
-  :body
-  (org-entry-blocked-p))
 
 ;; NOTE: Predicates defined: stop deferring and define normalizer and
 ;; preamble functions now.  Reversing preserves the order in which

--- a/org-ql.info
+++ b/org-ql.info
@@ -415,6 +415,9 @@ File: README.info,  Node: General predicates,  Next: Ancestor/descendant predica
 
 Arguments are listed next to predicate names, where applicable.
 
+‘blocked’
+     Return non-nil if current heading is blocked.  Calls
+     ‘org-entry-blocked-p’, which see.
 ‘category (&optional categories)’
      Return non-nil if current heading is in one or more of ‘CATEGORIES’
      (a list of strings).
@@ -1042,6 +1045,8 @@ File: README.info,  Node: 07-pre,  Next: 063,  Up: Changelog
      entries with property inheritance, and when unspecified, the option
      ‘org-use-property-inheritance’ controls whether inheritance is
      used.
+   • Predicate ‘blocked’.  (Thanks to Akira Komamura
+     (https://github.com/akirak).)
 
    *Changed*
    • Give more useful error message for invalid queries.
@@ -1711,52 +1716,52 @@ Node: org-ql-sparse-tree8594
 Node: Queries9394
 Node: Non-sexp query syntax10511
 Node: General predicates12270
-Node: Ancestor/descendant predicates19142
-Node: Date/time predicates20270
-Node: Functions / Macros23394
-Node: Agenda-like views23692
-Ref: Function ‘org-ql-block’23854
-Node: Listing / acting-on results25115
-Ref: Caching25323
-Ref: Function ‘org-ql-select’26236
-Ref: Function ‘org-ql-query’28662
-Ref: Macro ‘org-ql’ (deprecated)30436
-Node: Custom predicates30751
-Ref: Macro ‘org-ql-defpred’30975
-Node: Dynamic block34416
-Node: Links37140
-Node: Tips37827
-Node: Changelog38151
-Node: 07-pre38934
-Node: 06341436
-Node: 06241971
-Node: 06142276
-Node: 0642844
-Node: 05245898
-Node: 05146198
-Node: 0546621
-Node: 04948150
-Node: 04848430
-Node: 04748779
-Node: 04649188
-Node: 04549596
-Node: 04449957
-Node: 04350316
-Node: 04250519
-Node: 04150680
-Node: 0450927
-Node: 03255028
-Node: 03155431
-Node: 0355628
-Node: 02358928
-Node: 02259162
-Node: 02159442
-Node: 0259647
-Node: 0163725
-Node: Notes63826
-Node: Comparison with Org Agenda searches63988
-Node: org-sidebar64877
-Node: License65156
+Node: Ancestor/descendant predicates19257
+Node: Date/time predicates20385
+Node: Functions / Macros23509
+Node: Agenda-like views23807
+Ref: Function ‘org-ql-block’23969
+Node: Listing / acting-on results25230
+Ref: Caching25438
+Ref: Function ‘org-ql-select’26351
+Ref: Function ‘org-ql-query’28777
+Ref: Macro ‘org-ql’ (deprecated)30551
+Node: Custom predicates30866
+Ref: Macro ‘org-ql-defpred’31090
+Node: Dynamic block34531
+Node: Links37255
+Node: Tips37942
+Node: Changelog38266
+Node: 07-pre39049
+Node: 06341645
+Node: 06242180
+Node: 06142485
+Node: 0643053
+Node: 05246107
+Node: 05146407
+Node: 0546830
+Node: 04948359
+Node: 04848639
+Node: 04748988
+Node: 04649397
+Node: 04549805
+Node: 04450166
+Node: 04350525
+Node: 04250728
+Node: 04150889
+Node: 0451136
+Node: 03255237
+Node: 03155640
+Node: 0355837
+Node: 02359137
+Node: 02259371
+Node: 02159651
+Node: 0259856
+Node: 0163934
+Node: Notes64035
+Node: Comparison with Org Agenda searches64197
+Node: org-sidebar65086
+Node: License65365
 
 End Tag Table
 


### PR DESCRIPTION
I have been using this predicate in my config to filter out blocked tasks. I think this can be useful to others, so I am sending a PR.

In most cases, I combine this predicate with negation as follows:

```emacs-lisp
(and (todo)
  (not (blocked))
  ...)
```