### PR TITLE
Change: Don't depend on deprecated dash-functional

### DIFF
--- a/examples/org-bills-due.el
+++ b/examples/org-bills-due.el
@@ -24,7 +24,6 @@
 
 ;; From MELPA
 (require 'dash)
-(require 'dash-functional)
 (require 's)
 
 ;; org-ql

--- a/helm-org-ql.el
+++ b/helm-org-ql.el
@@ -3,7 +3,7 @@
 ;; Author: Adam Porter <adam@alphapapa.net>
 ;; URL: https://github.com/alphapapa/org-ql
 ;; Version: 0.6-pre
-;; Package-Requires: ((emacs "26.1") (dash "2.17.0") (s "1.12.0") (helm-org "1.0") (org-ql "0.6-pre"))
+;; Package-Requires: ((emacs "26.1") (dash "2.18.0") (s "1.12.0") (helm-org "1.0") (org-ql "0.6-pre"))
 
 ;;; Commentary:
 

--- a/org-ql.el
+++ b/org-ql.el
@@ -3,7 +3,7 @@
 ;; Author: Adam Porter <adam@alphapapa.net>
 ;; Url: https://github.com/alphapapa/org-ql
 ;; Version: 0.6-pre
-;; Package-Requires: ((emacs "26.1") (dash "2.13") (dash-functional "1.2.0") (f "0.17.2") (map "2.1") (org "9.0") (org-super-agenda "1.2") (ov "1.0.6") (peg "1.0") (s "1.12.0") (transient "0.1") (ts "0.2-pre"))
+;; Package-Requires: ((emacs "26.1") (dash "2.18") (f "0.17.2") (map "2.1") (org "9.0") (org-super-agenda "1.2") (ov "1.0.6") (peg "1.0") (s "1.12.0") (transient "0.1") (ts "0.2-pre"))
 ;; Keywords: hypermedia, outlines, Org, agenda
 
 ;;; Commentary:
@@ -41,7 +41,6 @@
 (require 'subr-x)
 
 (require 'dash)
-(require 'dash-functional)
 (require 'map)
 (require 'ts)
 


### PR DESCRIPTION
Dash 2.18.0 now subsumes `dash-functional`.

See https://github.com/magnars/dash.el/blob/master/NEWS.md#from-217-to-218