### PR TITLE
Change: Use (apply #'append) for flattening a list

### DIFF
--- a/org-ql.el
+++ b/org-ql.el
@@ -269,7 +269,7 @@ returns nil or non-nil."
                                          (user-error "Not an Org buffer: %s" (buffer-name)))
                                        (org-ql--select-cached :query query :preamble preamble :preamble-case-fold preamble-case-fold
                                                               :predicate predicate :action action :narrow narrow)))
-                              (-flatten-n 1)))
+                              (apply #'append)))
                      (--each orig-fns
                        ;; Restore original function mappings.
                        (-let (((&plist :name :fn) it))


### PR DESCRIPTION
`-flatten-n` was rewritten at https://github.com/magnars/dash.el/commit/0b9cdbaa31c7ae2406722fd9c534aad8f38fa1d5, and `(apply #'append)` is (possibly a bit) faster than `(-flatten-n 1)`.

This also fixes #179 which is caused by a bug introduced to dash.el at some point before 2.18. Note: That bug has been already fixed in the latest version of dash.