### PR TITLE
Use buffer-chars-modified-tick instead of buffer-modified-tick

### DIFF
--- a/README.org
+++ b/README.org
@@ -550,6 +550,7 @@ Simple links may also be written manually in either sexp or non-sexp form, like:
 
 *Internal*
 +  Certain query predicates, when called multiple times in an ~and~ sub-expression, are optimized to a single call.
++  Use ~buffer-chars-modified-tick~ instead of ~buffer-modified-tick~.  (Thanks to [[https://github.com/yantar92][Ihor Radchenko]].)
 
 ** 0.6.2
 

--- a/org-ql.el
+++ b/org-ql.el
@@ -481,7 +481,7 @@ NARROW corresponds to the `org-ql-select' argument NARROW."
     (if-let* ((buffer-cache (gethash (current-buffer) org-ql-cache))
               (query-cache (cadr buffer-cache))
               (modified-tick (car buffer-cache))
-              (buffer-unmodified-p (eq (buffer-modified-tick) modified-tick))
+              (buffer-unmodified-p (eq (buffer-chars-modified-tick) modified-tick))
               (cached-result (gethash query-cache-key query-cache)))
         (pcase cached-result
           ('org-ql-nil nil)
@@ -490,7 +490,7 @@ NARROW corresponds to the `org-ql-select' argument NARROW."
         (cond ((or (not query-cache)
                    (not buffer-unmodified-p))
                (puthash (current-buffer)
-                        (list (buffer-modified-tick)
+                        (list (buffer-chars-modified-tick)
                               (let ((table (make-hash-table :test 'org-ql-hash-test)))
                                 (puthash query-cache-key (or new-result 'org-ql-nil) table)
                                 table))
@@ -545,7 +545,7 @@ Returns cons (INHERITED-TAGS . LOCAL-TAGS)."
   (if-let* ((buffer-cache (gethash (current-buffer) org-ql-tags-cache))
             (modified-tick (car buffer-cache))
             (tags-cache (cdr buffer-cache))
-            (buffer-unmodified-p (eq (buffer-modified-tick) modified-tick))
+            (buffer-unmodified-p (eq (buffer-chars-modified-tick) modified-tick))
             (cached-result (gethash position tags-cache)))
       ;; Found in cache: return them.
       ;; FIXME: Isn't `cached-result' a list of (INHERITED . LOCAL)?  It
@@ -586,12 +586,12 @@ Returns cons (INHERITED-TAGS . LOCAL-TAGS)."
       (setf buffer-cache (gethash (current-buffer) org-ql-tags-cache)
             modified-tick (car buffer-cache)
             tags-cache (cdr buffer-cache)
-            buffer-unmodified-p (eq (buffer-modified-tick) modified-tick))
+            buffer-unmodified-p (eq (buffer-chars-modified-tick) modified-tick))
       (unless (and buffer-cache buffer-unmodified-p)
         ;; Buffer-local tags cache empty or invalid: make new one.
         (setf tags-cache (make-hash-table))
         (puthash (current-buffer)
-                 (cons (buffer-modified-tick) tags-cache)
+                 (cons (buffer-chars-modified-tick) tags-cache)
                  org-ql-tags-cache))
       (puthash position all-tags tags-cache))))
 
@@ -622,7 +622,7 @@ Values compared with `equal'."
   (pcase (if-let* ((buffer-cache (gethash (current-buffer) org-ql-node-value-cache))
                    (modified-tick (car buffer-cache))
                    (position-cache (cdr buffer-cache))
-                   (buffer-unmodified-p (eq (buffer-modified-tick) modified-tick))
+                   (buffer-unmodified-p (eq (buffer-chars-modified-tick) modified-tick))
                    (value-cache (gethash position position-cache))
                    (cached-value (alist-get fn value-cache nil nil #'equal)))
              ;; Found in cache: return it.
@@ -637,13 +637,13 @@ Values compared with `equal'."
                    position-cache (cdr buffer-cache)
                    value-cache (when position-cache
                                  (gethash position position-cache))
-                   buffer-unmodified-p (eq (buffer-modified-tick) modified-tick))
+                   buffer-unmodified-p (eq (buffer-chars-modified-tick) modified-tick))
              (unless (and buffer-cache buffer-unmodified-p)
                ;; Buffer-local node cache empty or invalid: make new one.
                (setf position-cache (make-hash-table)
                      value-cache (gethash position position-cache))
                (puthash (current-buffer)
-                        (cons (buffer-modified-tick) position-cache)
+                        (cons (buffer-chars-modified-tick) position-cache)
                         org-ql-node-value-cache))
              (setf (alist-get fn value-cache nil nil #'equal) new-value)
              (puthash position value-cache position-cache)

--- a/org-ql.info
+++ b/org-ql.info
@@ -1034,6 +1034,8 @@ File: README.info,  Node: 07-pre,  Next: 062,  Up: Changelog
    *Internal*
    • Certain query predicates, when called multiple times in an ‘and’
      sub-expression, are optimized to a single call.
+   • Use ‘buffer-chars-modified-tick’ instead of ‘buffer-modified-tick’.
+     (Thanks to Ihor Radchenko (https://github.com/yantar92).)
 
 
 File: README.info,  Node: 062,  Next: 061,  Prev: 07-pre,  Up: Changelog
@@ -1679,34 +1681,34 @@ Node: Links36761
 Node: Tips37448
 Node: Changelog37772
 Node: 07-pre38540
-Node: 06239801
-Node: 06140109
-Node: 0640677
-Node: 05243731
-Node: 05144031
-Node: 0544454
-Node: 04945983
-Node: 04846263
-Node: 04746610
-Node: 04647019
-Node: 04547427
-Node: 04447788
-Node: 04348147
-Node: 04248350
-Node: 04148511
-Node: 0448758
-Node: 03252859
-Node: 03153262
-Node: 0353459
-Node: 02356759
-Node: 02256993
-Node: 02157273
-Node: 0257478
-Node: 0161556
-Node: Notes61657
-Node: Comparison with Org Agenda searches61819
-Node: org-sidebar62708
-Node: License62987
+Node: 06239947
+Node: 06140255
+Node: 0640823
+Node: 05243877
+Node: 05144177
+Node: 0544600
+Node: 04946129
+Node: 04846409
+Node: 04746756
+Node: 04647165
+Node: 04547573
+Node: 04447934
+Node: 04348293
+Node: 04248496
+Node: 04148657
+Node: 0448904
+Node: 03253005
+Node: 03153408
+Node: 0353605
+Node: 02356905
+Node: 02257139
+Node: 02157419
+Node: 0257624
+Node: 0161702
+Node: Notes61803
+Node: Comparison with Org Agenda searches61965
+Node: org-sidebar62854
+Node: License63133
 
 End Tag Table
 


### PR DESCRIPTION
`buffer-modified-tick` invalidates buffer cache even when changes to text properties are made (i.e. each time agenda view is refreshed). `buffer-chars-modified-tick` reacts only to actual canges in buffer text. AFAIK there is no reason to invalidate change when text in org buffer is not changed.