### PR TITLE
[WIP] Implement boolean preambles

### DIFF
--- a/org-ql.el
+++ b/org-ql.el
@@ -367,7 +367,8 @@ If NARROW is non-nil, buffer will not be widened."
       (unless narrow
         (widen))
       (goto-char (point-min))
-      (when (org-before-first-heading-p)
+      (when (and (org-before-first-heading-p)
+                 (not (org-at-heading-p)))
         (outline-next-heading))
       (if (not (org-at-heading-p))
           (progn
@@ -769,18 +770,8 @@ This function is defined by calling
 defined in `org-ql-predicates' by calling `org-ql-defpred'."
               (cl-labels ((rec (element)
                                (pcase element
-                                 (`(or . ,clauses) `(or ,@(mapcar #'rec clauses)))
-                                 (`(and . ,clauses) `(and ,@(mapcar #'rec clauses)))
-                                 (`(not . ,clauses) `(not ,@(mapcar #'rec clauses)))
-                                 (`(when ,condition . ,clauses) `(when ,(rec condition)
-                                                                   ,@(mapcar #'rec clauses)))
-                                 (`(unless ,condition . ,clauses) `(unless ,(rec condition)
-                                                                     ,@(mapcar #'rec clauses)))
-                                 ;; TODO: Combine (regexp) when appropriate (i.e. inside an OR, not an AND).
                                  ((pred stringp) `(regexp ,element))
-
                                  ,@normalizer-patterns
-
                                  ;; Any other form: passed through unchanged.
                                  (_ element))))
                 (rec query)))))))
@@ -794,12 +785,7 @@ PREDICATES should be the value of `org-ql-predicates'."
                          ;; NOTE: Using -let instead of pcase-let here because I can't make map 2.1 install in the test sandbox.
                          (--map (-let* (((&plist :preambles) (cdr it)))
                                   (--map (pcase-let* ((`(,pattern ,exp) it))
-                                           `(,pattern
-                                             (-let* (((&plist :regexp :case-fold :query) ,exp))
-                                               (setf org-ql-preamble regexp
-                                                     preamble-case-fold case-fold)
-                                               ;; NOTE: Even when `predicate' is nil, it must be returned in the pcase form.
-                                               query)))
+                                           `(,pattern ,exp))
                                          preambles))
                                 predicates)))))
     (fset 'org-ql--query-preamble
@@ -824,30 +810,21 @@ This function is defined by calling
 defined in `org-ql-predicates' by calling `org-ql-defpred'."
              (pcase org-ql-use-preamble
                ('nil (list :query query :preamble nil))
-               (_ (let ((preamble-case-fold t)
-                        org-ql-preamble)
-                    (cl-labels ((rec (element)
-                                     (or (when org-ql-preamble
-                                           ;; Only one preamble is allowed
-                                           element)
-                                         (pcase element
-                                           (`(or _) element)
-
-                                           ,@preamble-patterns
-
-                                           (`(and . ,rest)
-                                            (let ((clauses (mapcar #'rec rest)))
-                                              `(and ,@(-non-nil clauses))))
-                                           (_ element)))))
-                      (setq query (pcase (mapcar #'rec (list query))
-                                    ((or `(nil)
+               (_ (cl-labels ((rec (element)
+                                   (pcase element
+                                     ,@preamble-patterns
+                                     (_ (list :query element)))))
+                    (-let* (((&plist :regexp :case-fold :query) (funcall #'rec query)))
+                      (setq query (pcase query
+                                    ((or `nil
+                                         `(nil)
                                          `((nil))
                                          `((and))
                                          `((or)))
                                      t)
                                     (`(t) t)
-                                    (query (-flatten-n 1 query))))
-                      (list :query query :preamble org-ql-preamble :preamble-case-fold preamble-case-fold)))))))
+                                    (_ query)))
+                      (list :query query :preamble regexp :preamble-case-fold case-fold)))))))
     ;; For some reason, byte-compiling the backquoted lambda form directly causes a warning
     ;; that `query' refers to an unbound variable, even though that's not the case, and the
     ;; function still works.  But to avoid the warning, we byte-compile it afterward.
@@ -1005,6 +982,77 @@ predicates."
 ;; Improve load time by deferring the per-predicate preamble- and normalizer-function
 ;; redefinitions until all of the predicates have been defined.
 (setf org-ql-defpred-defer t)
+
+(org-ql-defpred org-ql--and (&rest clauses)
+  "Return non-nil if all the clauses match."
+  :normalizers ((`(and)
+                 nil)
+                (`(and . ,clauses)
+                 `(and ,@(mapcar #'rec clauses))))
+  :preambles ((`(and . ,clauses)
+               (let ((preambles (mapcar #'rec clauses))
+                     regexps regexp-max case-fold-max)
+                 (dolist (preamble preambles)
+                   (-let* (((&plist :regexp :case-fold :query) preamble))
+                     ;; Take the longest regexp.  It should be hardest to match.
+                     (when (length> regexp (length regexp-max))
+                       (setq regexp-max regexp)
+                       (setq case-fold-max case-fold))))
+                 (list :regexp regexp-max
+                       :case-fold case-fold-max
+                       :query `(and ,@clauses))))))
+
+(org-ql-defpred org-ql--or (&rest clauses)
+  "Return non-nil if any of the clauses match."
+  :normalizers ((`(or)
+                 nil)
+                (`(or . ,clauses)
+                 `(or ,@(mapcar #'rec clauses))))
+  :preambles ((`(or . ,clauses)
+               (let ((preambles (mapcar #'rec clauses))
+                     regexps regexp-null-p)
+                 (dolist (preamble preambles)
+                   (-let* (((&plist :regexp :case-fold :query) preamble))
+                     ;; Collect regexps for combining.
+                     (if regexp (push regexp regexps)
+                       (setq regexp-null-p t))))
+                 (list :regexp (unless regexp-null-p
+                                 (and regexps
+                                      (rx-to-string `(or ,@(mapcar (lambda (re) `(regex ,re)) regexps)))))
+                       :case-fold t
+                       :query `(save-excursion (or ,@clauses)))))))
+
+(org-ql-defpred org-ql--when (condition &rest clauses)
+  "Return values of CLAUSES when CONDITION is non-nil."
+  :normalizers
+  ((`(when ,condition . ,clauses)
+    `(when ,(rec condition)
+       ,@(mapcar #'rec clauses))))
+  :preambles
+  ((`(when ,condition . ,clauses)
+    (-let* (((&plist :regexp :case-fold :query) (rec `(and ,condition ,(last clauses)))))
+      (list :regexp regexp
+            :case-fold case-fold
+            :query `(when ,condition ,@clauses))))))
+
+(org-ql-defpred org-ql--unless (condition &rest clauses)
+  "Return values of CLAUSES unless CONDITION is non-nil."
+  :normalizers
+  ((`(unless ,condition . ,clauses)
+    `(unless (save-excursion ,(rec condition))
+       ,@(mapcar #'rec clauses))))
+  :preambles
+  ((`(unless ,condition . ,clauses)
+    (-let* (((&plist :regexp :case-fold :query) (rec ,(last clauses))))
+      (list :regexp regexp
+            :case-fold case-fold
+            :query `(unless ,condition ,@clauses))))))
+
+(org-ql-defpred org-ql--not (clauses)
+  "Match when CLAUSES don't match."
+  :normalizers
+  ((`(not . ,clauses)
+    `(save-excursion (not ,@(mapcar #'rec clauses))))))
 
 (org-ql-defpred category (&rest categories)
   "Return non-nil if current heading is in one or more of CATEGORIES (a list of strings)."


### PR DESCRIPTION
I have been recently playing with idea of automatic preamble calculation for `(or ...)`, `(and ...)` and similar queries.

If I understand correctly, preamble is dropped on master for any boolean expression, except `(and ...)`. However, `(or ...)` could also be optimised if all the sexps inside `or` have non-nil predicates.

This pull request is a not-yet-ready-to-merge draft where I want to ask your opinion about this idea. I implemented boolean expressions `(and ...)`, `(or ...)`, `(when ...)`, `(unless ...)`, and `(not ...)` as actual predicates, so that  preambles can be transparently defined. 

Some benchmarks with `elp` on my setup with complex agenda queries:

;;Function  number_of_invocations  total_time average_time

;; Old (agenda n)
;;org-agenda               1           45.655149553  45.655149553
;;org-ql--select           2255        37.698226351  0.0167176170
;;re-search-forward        336625      6.2799195780  1.865...e-05
;;org-ql--query-preamble   2265        0.0108973820  4.811...e-06
;;org-ql--normalize-query  2265        0.0088714750  3.916...e-06

;; New (agenda n)
;;org-agenda               1           22.979330424  22.979330424
;;org-ql--select           1261        15.829318511  0.0125529885
;;re-search-forward        256703      4.8654712150  1.895...e-05
;;org-ql--normalize-query  1274        0.0073856340  5.797...e-06
;;org-ql--query-preamble   1274        0.0045016170  3.533...e-06

Note the difference in number of `re-search-forward` calls: 256703 (new) vs. 336625 (old). This is mostly because `(or ...)` queries can now have preamble. I have seen up to several times less calls depending on what kind of query I am using.

The caveat is (sometimes) increased time spend on each `re-search-forward`. Combined preamble for `(or ...)` consists of `(rx `(| individual-preambles))` increasing the complexity of preamble regexp. For very small queries involving many timestamps, regexp search sometimes ate up all the speed improvement as the time for each individual regexp search increased several times.

