### PR TITLE
Fix: Abbreviate file paths in created org-ql bookmarks

### DIFF
--- a/README.org
+++ b/README.org
@@ -533,6 +533,7 @@ Simple links may also be written manually in either sexp or non-sexp form, like:
      -  ~reverse~
      -  ~closed~  (Thanks to [[https://github.com/yejianye][Ryan Ye]].)
 +  Dynamic block column ~closed~.  (Thanks to [[https://github.com/yejianye][Ryan Ye]].)
++  Abbreviate filenames in bookmarks.  (Thanks to [[https://github.com/akirak][Akira Komamura]].)
 
 *Changed*
 +  The order in which sorting functions is applied has been reversed.  For example, ~:sort '(todo priority date)~ now does what ~:sort '(date priority todo)~ did in earlier versions.  (This change is made to enable the new ~reverse~ sorting method.)  Users who have customized =org-ql-views= will need to update the stored views' sorting methods to preserve the desired sort order.

--- a/org-ql-view.el
+++ b/org-ql-view.el
@@ -533,12 +533,13 @@ dates in the past, and negative for dates in the future."
 (defun org-ql-view-bookmark-make-record ()
   "Return a bookmark record for the current Org QL View buffer."
   (cl-labels ((file-nameize
-               (b-f) (cl-typecase b-f
-                       (string b-f)
-                       (buffer (or (buffer-file-name b-f)
-                                   (when (buffer-base-buffer b-f)
-                                     (buffer-file-name (buffer-base-buffer b-f)))))
-                       (t (user-error "Only file-backed buffers can be bookmarked by Org QL View: %s" b-f)))))
+               (b-f) (abbreviate-file-name
+                      (cl-typecase b-f
+                        (string b-f)
+                        (buffer (or (buffer-file-name b-f)
+                                    (when (buffer-base-buffer b-f)
+                                      (buffer-file-name (buffer-base-buffer b-f)))))
+                        (t (user-error "Only file-backed buffers can be bookmarked by Org QL View: %s" b-f))))))
     (-let* ((plist (org-ql-view--plist (current-buffer)))
             ((&plist :buffers-files) plist))
       ;; Replace buffers with their filenames, and signal error if any are not file-backed.

--- a/org-ql.info
+++ b/org-ql.info
@@ -1000,6 +1000,8 @@ File: README.info,  Node: 06-pre,  Next: 052,  Up: Changelog
         • ‘closed’ (Thanks to Ryan Ye (https://github.com/yejianye).)
    • Dynamic block column ‘closed’.  (Thanks to Ryan Ye
      (https://github.com/yejianye).)
+   • Abbreviate filenames in bookmarks.  (Thanks to Akira Komamura
+     (https://github.com/akirak).)
 
    *Changed*
    • The order in which sorting functions is applied has been reversed.
@@ -1579,31 +1581,31 @@ Node: Links35356
 Node: Tips36043
 Node: Changelog36361
 Node: 06-pre37087
-Node: 05239852
-Node: 05140156
-Node: 0540573
-Node: 04942047
-Node: 04842321
-Node: 04742668
-Node: 04643063
-Node: 04543463
-Node: 04443822
-Node: 04344181
-Node: 04244378
-Node: 04144539
-Node: 0444780
-Node: 03248713
-Node: 03149092
-Node: 0349289
-Node: 02352264
-Node: 02252492
-Node: 02152760
-Node: 0252959
-Node: 0156994
-Node: Notes57095
-Node: Comparison with Org Agenda searches57257
-Node: org-sidebar58129
-Node: License58408
+Node: 05239956
+Node: 05140260
+Node: 0540677
+Node: 04942151
+Node: 04842425
+Node: 04742772
+Node: 04643167
+Node: 04543567
+Node: 04443926
+Node: 04344285
+Node: 04244482
+Node: 04144643
+Node: 0444884
+Node: 03248817
+Node: 03149196
+Node: 0349393
+Node: 02352368
+Node: 02252596
+Node: 02152864
+Node: 0253063
+Node: 0157098
+Node: Notes57199
+Node: Comparison with Org Agenda searches57361
+Node: org-sidebar58233
+Node: License58512
 
 End Tag Table
 


### PR DESCRIPTION
Hello,

In bookmarks created by this package, file names were in absolute paths like `/home/USER/org/xxx.org`. This is problematic if you have the same bookmark file on machines with different user names. Abbreviation prevents this issue.