### PR TITLE
Fix: pcase pattern shadowed

### DIFF
--- a/org-ql.el
+++ b/org-ql.el
@@ -1750,8 +1750,7 @@ Tests both inherited and local tags."
 (org-ql-defpred (tags-inherited inherited-tags tags-i itags) (&rest tags)
   "Return non-nil if current heading's inherited tags include one or more of TAGS (a list of strings).
 If TAGS is nil, return non-nil if heading has any inherited tags."
-  :normalizers ((`(,predicate-names) `(tags-inherited))
-                (`(,predicate-names . ,tags) `(tags-inherited ,@tags)))
+  :normalizers ((`(,predicate-names . ,tags) `(tags-inherited ,@tags)))
   :body (cl-macrolet ((tags-p (tags)
                               `(and ,tags
                                     (not (eq 'org-ql-nil ,tags)))))

--- a/org-ql.el
+++ b/org-ql.el
@@ -1750,10 +1750,8 @@ Tests both inherited and local tags."
 (org-ql-defpred (tags-inherited inherited-tags tags-i itags) (&rest tags)
   "Return non-nil if current heading's inherited tags include one or more of TAGS (a list of strings).
 If TAGS is nil, return non-nil if heading has any inherited tags."
-  :normalizers ((`(,predicate-names . ,tags)
-                 `(tags-inherited ,@tags))
-                (`(,predicate-names)
-                 `(tags-inherited)))
+  :normalizers ((`(,predicate-names) `(tags-inherited))
+                (`(,predicate-names . ,tags) `(tags-inherited ,@tags)))
   :body (cl-macrolet ((tags-p (tags)
                               `(and ,tags
                                     (not (eq 'org-ql-nil ,tags)))))

--- a/org-ql.el
+++ b/org-ql.el
@@ -1743,14 +1743,15 @@ Tests both inherited and local tags."
   "Return non-nil if current heading has all of TAGS (a list of strings).
 Tests both inherited and local tags."
   ;; MAYBE: -all versions for inherited and local.
-  :normalizers ((`(,predicate-names) `(tags))
-                (`(,predicate-names . ,tags) `(and ,@(--map `(tags ,it) tags))))
+  :normalizers ((`(,predicate-names . ,tags)
+                 `(and ,@(--map `(tags ,it) tags))))
   :body (apply #'org-ql--predicate-tags tags))
 
 (org-ql-defpred (tags-inherited inherited-tags tags-i itags) (&rest tags)
   "Return non-nil if current heading's inherited tags include one or more of TAGS (a list of strings).
 If TAGS is nil, return non-nil if heading has any inherited tags."
-  :normalizers ((`(,predicate-names . ,tags) `(tags-inherited ,@tags)))
+  :normalizers ((`(,predicate-names . ,tags)
+                 `(tags-inherited ,@tags)))
   :body (cl-macrolet ((tags-p (tags)
                               `(and ,tags
                                     (not (eq 'org-ql-nil ,tags)))))
@@ -1763,8 +1764,8 @@ If TAGS is nil, return non-nil if heading has any inherited tags."
 (org-ql-defpred (tags-local local-tags tags-l ltags) (&rest tags)
   "Return non-nil if current heading's local tags include one or more of TAGS (a list of strings).
 If TAGS is nil, return non-nil if heading has any local tags."
-  :normalizers ((`(,predicate-names) `(tags-local))
-                (`(,predicate-names . ,tags) `(tags-local ,@tags)))
+  :normalizers ((`(,predicate-names . ,tags)
+                 `(tags-local ,@tags)))
   :preambles ((`(,predicate-names . ,(and tags (guard tags)))
                ;; When searching for local, non-inherited tags, we can
                ;; search directly to headings containing one of the tags.


### PR DESCRIPTION
Hi,

   Looking at the code of tags-{all, local, inherited} when org-ql-defpred was introduced, it seems only tags-inherited didn't follow the same transformation and the normalizers were applied in reverse order. In latest emacs, it generates a shadow warning. Exchanging the lines eliminate it and I didn't notice any ill effect. If there is no trick hidden behind these lines order, could fix: #214 quite easily.