### PR TITLE
Fix bugs with the link predicate

### DIFF
--- a/org-ql.el
+++ b/org-ql.el
@@ -1137,17 +1137,24 @@ any link is found."
                          "]"
                          (or eol blank))))
               (`(,predicate-names ,(and description-or-target
-                                        (guard (not (keywordp description-or-target)))))
+                                        (guard (not (keywordp description-or-target))))
+                                  . ,plist)
                (list :regexp (org-ql--link-regexp :description-or-target
-                                                  (regexp-quote description-or-target)))
+                                                  (if (plist-get plist :regexp-p)
+                                                      description-or-target
+                                                    (regexp-quote description-or-target))))
                nil)
               (`(,predicate-names . ,plist)
                (list :regexp (org-ql--link-regexp
                               :description
                               (when (plist-get plist :description)
-                                (regexp-quote (plist-get plist :description)))
+                                (if (plist-get plist :regexp-p)
+                                    (plist-get plist :description)
+                                  (regexp-quote (plist-get plist :description))))
                               :target (when (plist-get plist :target)
-                                        (regexp-quote (plist-get plist :target)))))
+                                        (if (plist-get plist :regexp-p)
+                                            (plist-get plist :target)
+                                          (regexp-quote (plist-get plist :target))))))
                nil))
   :body (let* (plist description-or-target description target regexp-p)
           (if (not (keywordp (car args)))

--- a/org-ql.el
+++ b/org-ql.el
@@ -1155,7 +1155,7 @@ any link is found."
                     plist (cdr args))
             (setf plist args))
           (setf description (plist-get plist :description)
-                target (plist-get plist :description)
+                target (plist-get plist :target)
                 regexp-p (plist-get plist :regexp-p))
           (unless regexp-p
             ;; NOTE: It would also be preferable to avoid regexp-quoting every time this predicate


### PR DESCRIPTION
Hello, I found some bugs in `:link` predicate while I was working on my own package. Below are the issues, which are fixed in this PR:

- `:target` does not work, and org-ql returns an unfiltered result, i.e. all entries containing a link.
- When you set `:regexp-p` to t and pass a regular expression as an argument, org-ql returns an empty result.