### PR TITLE
Add Emacs 27.2 to CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,6 +43,7 @@ jobs:
         emacs_version:
           - 26.3
           - 27.1
+          - 27.2
           - snapshot
     steps:
     - uses: purcell/setup-emacs@master


### PR DESCRIPTION
CI currently fails on the snapshot of Emacs, so I think it might be useful to run the test on the latest stable version.