### PR TITLE
Fix org-ql-regexp-part-ts-date for repeaters like .+1d

### DIFF
--- a/org-ql.el
+++ b/org-ql.el
@@ -153,7 +153,7 @@ regexps.")
 
 (defvar org-ql-regexp-part-ts-repeaters
   ;; Repeaters (not sure if the colon is necessary, but it's in the org.el one)
-  (rx (repeat 1 2 (seq " " (repeat 1 2 (any "-+:")) (1+ digit) (any "hdwmy"))))
+  (rx (repeat 1 2 (seq " " (repeat 1 2 (any "-+:.")) (1+ digit) (any "hdwmy"))))
   "Matches the repeater part of an Org timestamp.
 Includes leading space character.")
 

--- a/tests/data.org
+++ b/tests/data.org
@@ -89,7 +89,7 @@ Gotta buy one first, though.  [[https://example.com/][This one]] looks suitable.
 :END:
 
 ** CHECK /r/emacs                                            :website:Emacs:
-DEADLINE: <2017-07-05 Wed +1w>
+DEADLINE: <2017-07-05 Wed .+1w>
 
 +  [[http://reddit.com/r/emacs][Link to /r/emacs]]
 


### PR DESCRIPTION
org-ql-regexp-part-ts-date currently does not match timestamps like <2021-06-23 Wed .+1d>.