### PR TITLE
Fix org-ql-regexp-part-ts-repeaters for repeaters like .+4d/6d

### DIFF
--- a/org-ql.el
+++ b/org-ql.el
@@ -153,7 +153,8 @@ regexps.")
 
 (defvar org-ql-regexp-part-ts-repeaters
   ;; Repeaters (not sure if the colon is necessary, but it's in the org.el one)
-  (rx (repeat 1 2 (seq " " (repeat 1 2 (any "-+:.")) (1+ digit) (any "hdwmy"))))
+  (rx (repeat 1 2 (seq " " (repeat 1 2 (any "-+:.")) (1+ digit) (any "hdwmy")
+                       (optional "/" (1+ digit) (any "hdwmy")))))
   "Matches the repeater part of an Org timestamp.
 Includes leading space character.")
 

--- a/tests/data.org
+++ b/tests/data.org
@@ -37,7 +37,7 @@ DEADLINE: <2017-08-27 Sun -2m>
   Just waiting on that callback from NASA...
 
 ** TODO Practice leaping tall buildings in a single bound         :personal:
-SCHEDULED: <2017-07-05 Wed +2d>
+SCHEDULED: <2017-07-05 Wed .+2d/3d>
 :PROPERTIES:
 :STYLE:    habit
 :END:


### PR DESCRIPTION
Yet another habit went missing from my agenda... Comparing with `org-repeat-re`, this final version of the regexp in org-ql should finally cover everything.