### PR TITLE
Fix: (org-dblock-write:org-ql) remove cookies in headings

### DIFF
--- a/org-ql-search.el
+++ b/org-ql-search.el
@@ -285,9 +285,9 @@ For example, an org-ql dynamic block header could look like:
            (list (cons 'todo (lambda (element)
                                (org-element-property :todo-keyword element)))
                  (cons 'heading (lambda (element)
-                                  (org-make-link-string (org-element-property :raw-value element)
+                                  (org-make-link-string (car (org-element-property :title element))
                                                         (org-link-display-format
-                                                         (org-element-property :raw-value element)))))
+                                                         (car (org-element-property :title element))))))
                  (cons 'priority (lambda (element)
                                    (--when-let (org-element-property :priority element)
                                      (char-to-string it))))

--- a/org-ql-search.el
+++ b/org-ql-search.el
@@ -285,9 +285,11 @@ For example, an org-ql dynamic block header could look like:
            (list (cons 'todo (lambda (element)
                                (org-element-property :todo-keyword element)))
                  (cons 'heading (lambda (element)
-                                  (org-make-link-string (car (org-element-property :title element))
+                                  (org-make-link-string (replace-regexp-in-string "\[[[:digit:]]*/[[:digit:]]*\]\\|\[[[:digit:]]*\%\]" "" 
+										  (org-element-property :raw-value element))
                                                         (org-link-display-format
-                                                         (car (org-element-property :title element))))))
+                                                         (replace-regexp-in-string "\[[[:digit:]]*/[[:digit:]]*\]\\|\[[[:digit:]]*\%\]" "" 
+										   (org-element-property :raw-value element))))))
                  (cons 'priority (lambda (element)
                                    (--when-let (org-element-property :priority element)
                                      (char-to-string it))))

--- a/org-ql-search.el
+++ b/org-ql-search.el
@@ -285,12 +285,14 @@ For example, an org-ql dynamic block header could look like:
            (list (cons 'todo (lambda (element)
                                (org-element-property :todo-keyword element)))
                  (cons 'heading (lambda (element)
-                                  (org-make-link-string (replace-regexp-in-string "\[[[:digit:]]*/[[:digit:]]*\]\\|\[[[:digit:]]*\%\]" "" 
-										  (org-element-property :raw-value element))
-                                                        (org-link-display-format
-                                                         (replace-regexp-in-string "\[[[:digit:]]*/[[:digit:]]*\]\\|\[[[:digit:]]*\%\]" "" 
-										   (org-element-property :raw-value element))))))
-                 (cons 'priority (lambda (element)
+					(org-make-link-string (s-trim (org-element-interpret-data
+                                                      (--remove (eq 'statistics-cookie (org-element-type it))
+                                                                (org-element-property :title element))))
+                                             (org-link-display-format
+                                              (s-trim (org-element-interpret-data
+                                                       (--remove (eq 'statistics-cookie (org-element-type it))
+                                                                 (org-element-property :title element))))))))
+	         (cons 'priority (lambda (element)
                                    (--when-let (org-element-property :priority element)
                                      (char-to-string it))))
                  (cons 'deadline (lambda (element)


### PR DESCRIPTION
Fix #248 

Uses `:title` instead of `raw-value` combined with a `car` to capture only the title of the heading. 
Now the links are properly formed even if there exist cookies (`[/]` or `[%]`).