### PR TITLE
helm-org-ql: add an 'input' argument

### DIFF
--- a/helm-org-ql.el
+++ b/helm-org-ql.el
@@ -93,7 +93,7 @@ Based on `helm-map'.")
 
 ;;;###autoload
 (cl-defun helm-org-ql (buffers-files
-                       &key (boolean 'and) (name "helm-org-ql"))
+                       &key (boolean 'and) (name "helm-org-ql") (input ""))
   "Display results in BUFFERS-FILES for an `org-ql' non-sexp query using Helm.
 Interactively, search the current buffer.  Note that this command
 only accepts non-sexp, \"plain\" queries.
@@ -125,7 +125,9 @@ Is transformed into this query:
   (let ((boolean (if current-prefix-arg 'or boolean))
         (helm-input-idle-delay helm-org-ql-input-idle-delay))
     (helm :prompt (format "Query (boolean %s): " (-> boolean symbol-name upcase))
-          :sources (helm-org-ql-source buffers-files :name name))))
+          :sources (helm-org-ql-source buffers-files :name name)
+          :input input
+          )))
 
 ;;;###autoload
 (defun helm-org-ql-agenda-files ()


### PR DESCRIPTION
To support customized helm-org-ql command with pre-filled portion