### PR TITLE
Fix: prevent preamble evaluation breaking completion framework

### DIFF
--- a/org-ql.el
+++ b/org-ql.el
@@ -1066,15 +1066,19 @@ defined in `org-ql-predicates' by calling `org-ql-defpred'."
                                      (or (when org-ql-preamble
                                            ;; Only one preamble is allowed
                                            element)
-                                         (pcase element
-                                           (`(or _) element)
+                                         (condition-case err
+                                             (pcase element
+                                               (`(or _) element)
 
-                                           ,@preamble-patterns
+                                               ,@preamble-patterns
 
-                                           (`(and . ,rest)
-                                            (let ((clauses (mapcar #'rec rest)))
-                                              `(and ,@(-non-nil clauses))))
-                                           (_ element)))))
+                                               (`(and . ,rest)
+                                                (let ((clauses (mapcar #'rec rest)))
+                                                  `(and ,@(-non-nil clauses))))
+                                               (_ element))
+                                           (error
+                                            (message "Preamble error: %s" err)
+                                            nil)))))
                       (setq query (pcase (mapcar #'rec (list query))
                                     ((or `(nil)
                                          `((nil))

--- a/org-ql.el
+++ b/org-ql.el
@@ -1410,7 +1410,7 @@ Matching is done case-insensitively."
                ;; Multiple strings: use preamble to match against first
                ;; string, then let the predicate match the rest.
                (list :regexp (rx-to-string `(seq bol (1+ "*") (1+ blank) (0+ nonl)
-                                                 ,(car strings))
+                                                 ,(or (car strings) ""))
                                            'no-group)
                      :case-fold t :query query)))
   ;; TODO: In Org 9.2+, `org-get-heading' takes 2 more arguments.


### PR DESCRIPTION
Hi @alphapapa,

I encountered an issue using the heading predicate with `org-ql-find` interactively. Typing `h:` throws an error which isn't caught, so in my case as a vertico user it prevents any more completion updates from displaying (i.e. typing into the completion minibuffer no longer updates the completions results list). I think this is an issue with org-ql, not vertico, because org-ql should either prevent the error or catch it.

---

## Reproduction

1. M-x `org-ql-find`
2. Type `h:`
3. Trigger completion (automatic in my case with vertico, `TAB` for default Emacs completion)

Result: backtrace that ends with
```
  error("Unknown rx symbol `%s'" nil)
  rx--translate-symbol(nil)
  rx--translate(nil)
  rx--translate-seq((bol (1+ "*") (1+ blank) (0+ nonl) nil))
  rx--translate-form((seq bol (1+ "*") (1+ blank) (0+ nonl) nil))
  rx--translate((seq bol (1+ "*") (1+ blank) (0+ nonl) nil))
  rx-to-string((seq bol (1+ "*") (1+ blank) (0+ nonl) nil) no-group)
  #f(compiled-function (strings) #<bytecode -0x5838b1a9927114e>)(nil)
  #f(compiled-function (element) #<bytecode -0x1eae36f5c2ca9854>)((heading))
  mapcar(#f(compiled-function (element) #<bytecode -0x1eae36f5c2ca9854>) ((heading)))
  org-ql--query-preamble((heading))
```

**Alternative reproduction method**: run the following elisp snippet and observe the backtrace.

```elisp
(let* ((query '(heading))
       (normalized (org-ql--normalize-query query))
       (preamble (org-ql--query-preamble normalized)))
  (list :query query
        :normalized normalized
        :preamble preamble))
```
---

## Fix

I made two different commits with different solutions: 
1. 83cc00a27d7e765df6faad2be7ebf5531d1a250a fixes the `heading` preamble specifically.
2. 62f4e0b1109963bb86dacb34666c9402547f3d89 adds error handling to prevent any preamble errors from propagating up.

You could use both commits or just one of them depending on what solution seems preferable to you. Let me know if you would prefer a different solution too.