### PR TITLE
Extending org-ql-open-link

### DIFF
--- a/org-ql-find.el
+++ b/org-ql-find.el
@@ -177,6 +177,21 @@ multiple buffers to search with completion and PROMPT."
     (org-with-point-at marker
       (org-open-at-point))))
 
+;;;###autoload
+(defun org-ql-open-link-in-agenda ()
+  "Call `org-ql-open-link' on `org-agenda-files'."
+  (interactive)
+  (org-ql-open-link (org-agenda-files)))
+
+;;;###autoload
+(defun org-ql-open-link-in-org-directory ()
+  "Call `org-ql-open-link' on files in `org-directory'. Set variable
+`org-ql-search-directories-files-recursive' to `t' to search the
+directory recursively."
+  (interactive)
+  (org-ql-open-link (org-ql-search-directories-files)))
+
+
 ;;;; Functions
 
 (defun org-ql-find--buffers ()


### PR DESCRIPTION
Extending `org-ql-open-link` to be able to search across multiple Org files from the agenda or a directory containing Org files (optionally recursively using org-ql-search-directories-files-recursive to true).

Those two new additions are based on `org-ql-find-in-agenda`. This enables to use `org-ql-open-link` but on multiple files from the Org agenda file or a specific directory.

This is very helpful for someone that has a lot of Org/ROAM files with a lot of external links to be able to use its Org knowledge base as a place where bookmarks exists (better contextualized than a series of bookmarks in a browser).