### PR TITLE
Remove mentions of org-ql-find-heading, org-ql-find-path from Changelog.

### DIFF
--- a/README.org
+++ b/README.org
@@ -553,6 +553,10 @@ Simple links may also be written manually in either sexp or non-sexp form, like:
 
 /Note:/ Breaking changes may be made before version 1.0, but in the event of major changes, attempts at backward compatibility will be made with obsolescence declarations, translation of arguments, etc.  Users who need stability guarantees before 1.0 may choose to use tagged stable releases.
 
+** 0.8.1-pre
+
+Nothing new yet.
+
 ** 0.8
 
 *Additions*

--- a/README.org
+++ b/README.org
@@ -558,6 +558,7 @@ Simple links may also be written manually in either sexp or non-sexp form, like:
 *Fixes*
 
 + Command ~org-ql-find~ widens the buffer before going to the selected entry.
++ In ~org-ql-view~ buffers, links in headings remain clickable links.  (Fixes [[https://github.com/alphapapa/org-ql/issues/282][#282]].  Thanks to [[https://github.com/jakebox][Jacob Boxerman]] for reporting.)
 
 ** 0.8
 

--- a/README.org
+++ b/README.org
@@ -611,7 +611,7 @@ Simple links may also be written manually in either sexp or non-sexp form, like:
 ** 0.7
 
 *Added*
-+  Commands ~org-ql-find~, ~org-ql-find-heading~, and ~org-ql-find-path~, which jump to entries selected using Emacs's built-in completion facilities and Org QL queries (like ~helm-org-ql~, but doesn't require Helm.).
++  Command ~org-ql-find~, which jumps to entries selected using Emacs's built-in completion facilities and Org QL queries (like ~helm-org-ql~, but doesn't require Helm.).
 +  Command ~org-ql-refile~, which refiles the entry at point to one selected using Org QL completion.
 +  Predicate ~rifle~, which matches an entry if each of the given arguments is found in either the entry's contents or its outline path.  This provides very intuitive results, mimicing the behavior of [[https://github.com/alphapapa/org-rifle][=org-rifle=]].  In fact, the results are so useful that it's now the default predicate for plain-string query tokens.  (It is also aliased to ~smart~, since it's so "smart," and not all users have used =org-rifle=.)
 +  Option ~org-ql-default-predicate~, applied to plain-string query tokens (before, the ~regexp~ predicate was always used, but now it may be customized).

--- a/README.org
+++ b/README.org
@@ -555,7 +555,9 @@ Simple links may also be written manually in either sexp or non-sexp form, like:
 
 ** 0.8.1-pre
 
-Nothing new yet.
+*Fixes*
+
++ Command ~org-ql-find~ widens the buffer before going to the selected entry.
 
 ** 0.8
 

--- a/org-ql-find.el
+++ b/org-ql-find.el
@@ -77,8 +77,8 @@ single predicate)."
                   :prompt prompt)))
     (set-buffer (marker-buffer marker))
     (pop-to-buffer (current-buffer) org-ql-find-display-buffer-action)
-    (goto-char marker)
-    (run-hook-with-args 'org-ql-find-goto-hook)))
+    (org-with-point-at marker
+      (run-hook-with-args 'org-ql-find-goto-hook))))
 
 ;;;###autoload
 (defun org-ql-refile (marker)

--- a/org-ql-view.el
+++ b/org-ql-view.el
@@ -869,8 +869,7 @@ return an empty string."
            ;; Adding the relative due date property should probably be done explicitly and separately
            ;; (which would also make it easier to do it independently of faces, etc).
            (title (--> (org-ql-view--add-faces element)
-                       (org-element-property :raw-value it)
-                       (org-link-display-format it)))
+                       (org-element-property :raw-value it)))
            (todo-keyword (-some--> (org-element-property :todo-keyword element)
                            (org-ql-view--add-todo-face it)))
            (tag-list (if org-use-tag-inheritance

--- a/org-ql.el
+++ b/org-ql.el
@@ -4,7 +4,7 @@
 
 ;; Author: Adam Porter <adam@alphapapa.net>
 ;; Url: https://github.com/alphapapa/org-ql
-;; Version: 0.8
+;; Version: 0.8.1-pre
 ;; Package-Requires: ((emacs "27.1") (compat "29.1") (dash "2.18.1") (f "0.17.2") (map "2.1") (org "9.0") (org-super-agenda "1.2") (ov "1.0.6") (peg "1.0.1") (s "1.12.0") (transient "0.1") (ts "0.2-pre"))
 ;; Keywords: hypermedia, outlines, Org, agenda
 

--- a/org-ql.info
+++ b/org-ql.info
@@ -1072,6 +1072,10 @@ File: README.info,  Node: 081-pre,  Next: 08,  Up: Changelog
 
    • Command ‘org-ql-find’ widens the buffer before going to the
      selected entry.
+   • In ‘org-ql-view’ buffers, links in headings remain clickable links.
+     (Fixes #282 (https://github.com/alphapapa/org-ql/issues/282).
+     Thanks to Jacob Boxerman (https://github.com/jakebox) for
+     reporting.)
 
 
 File: README.info,  Node: 08,  Next: 074,  Prev: 081-pre,  Up: Changelog
@@ -1919,41 +1923,41 @@ Node: Links38827
 Node: Tips39514
 Node: Changelog39838
 Node: 081-pre40676
-Node: 0840871
-Node: 07443599
-Node: 07343822
-Node: 07244554
-Node: 07145473
-Node: 0746282
-Node: 06349206
-Node: 06249737
-Node: 06150042
-Node: 0650612
-Node: 05253668
-Node: 05153970
-Node: 0554395
-Node: 04955926
-Node: 04856208
-Node: 04756557
-Node: 04656966
-Node: 04557374
-Node: 04457735
-Node: 04358094
-Node: 04258297
-Node: 04158458
-Node: 0458705
-Node: 03262806
-Node: 03163209
-Node: 0363406
-Node: 02366706
-Node: 02266940
-Node: 02167220
-Node: 0267425
-Node: 0171503
-Node: Notes71604
-Node: Comparison with Org Agenda searches71766
-Node: org-sidebar72655
-Node: License72934
+Node: 0841097
+Node: 07443825
+Node: 07344048
+Node: 07244780
+Node: 07145699
+Node: 0746508
+Node: 06349432
+Node: 06249963
+Node: 06150268
+Node: 0650838
+Node: 05253894
+Node: 05154196
+Node: 0554621
+Node: 04956152
+Node: 04856434
+Node: 04756783
+Node: 04657192
+Node: 04557600
+Node: 04457961
+Node: 04358320
+Node: 04258523
+Node: 04158684
+Node: 0458931
+Node: 03263032
+Node: 03163435
+Node: 0363632
+Node: 02366932
+Node: 02267166
+Node: 02167446
+Node: 0267651
+Node: 0171729
+Node: Notes71830
+Node: Comparison with Org Agenda searches71992
+Node: org-sidebar72881
+Node: License73160
 
 End Tag Table
 

--- a/org-ql.info
+++ b/org-ql.info
@@ -72,6 +72,7 @@ Functions / Macros
 
 Changelog
 
+* 0.8.1-pre: 081-pre.
 * 0.8: 08.
 * 0.7.4: 074.
 * 0.7.3: 073.
@@ -1028,6 +1029,7 @@ releases.
 
 * Menu:
 
+* 0.8.1-pre: 081-pre.
 * 0.8: 08.
 * 0.7.4: 074.
 * 0.7.3: 073.
@@ -1061,9 +1063,17 @@ releases.
 * 0.1: 01.
 
 
-File: README.info,  Node: 08,  Next: 074,  Up: Changelog
+File: README.info,  Node: 081-pre,  Next: 08,  Up: Changelog
 
-5.1 0.8
+5.1 0.8.1-pre
+=============
+
+Nothing new yet.
+
+
+File: README.info,  Node: 08,  Next: 074,  Prev: 081-pre,  Up: Changelog
+
+5.2 0.8
 =======
 
 *Additions*
@@ -1119,7 +1129,7 @@ File: README.info,  Node: 08,  Next: 074,  Up: Changelog
 
 File: README.info,  Node: 074,  Next: 073,  Prev: 08,  Up: Changelog
 
-5.2 0.7.4
+5.3 0.7.4
 =========
 
 *Fixes*
@@ -1129,7 +1139,7 @@ File: README.info,  Node: 074,  Next: 073,  Prev: 08,  Up: Changelog
 
 File: README.info,  Node: 073,  Next: 072,  Prev: 074,  Up: Changelog
 
-5.3 0.7.3
+5.4 0.7.3
 =========
 
 *Fixes*
@@ -1147,7 +1157,7 @@ File: README.info,  Node: 073,  Next: 072,  Prev: 074,  Up: Changelog
 
 File: README.info,  Node: 072,  Next: 071,  Prev: 073,  Up: Changelog
 
-5.4 0.7.2
+5.5 0.7.2
 =========
 
 *Fixes*
@@ -1168,7 +1178,7 @@ File: README.info,  Node: 072,  Next: 071,  Prev: 073,  Up: Changelog
 
 File: README.info,  Node: 071,  Next: 07,  Prev: 072,  Up: Changelog
 
-5.5 0.7.1
+5.6 0.7.1
 =========
 
 *Fixes*
@@ -1187,7 +1197,7 @@ File: README.info,  Node: 071,  Next: 07,  Prev: 072,  Up: Changelog
 
 File: README.info,  Node: 07,  Next: 063,  Prev: 071,  Up: Changelog
 
-5.6 0.7
+5.7 0.7
 =======
 
 *Added*
@@ -1247,7 +1257,7 @@ File: README.info,  Node: 07,  Next: 063,  Prev: 071,  Up: Changelog
 
 File: README.info,  Node: 063,  Next: 062,  Prev: 07,  Up: Changelog
 
-5.7 0.6.3
+5.8 0.6.3
 =========
 
 *Fixed*
@@ -1263,7 +1273,7 @@ File: README.info,  Node: 063,  Next: 062,  Prev: 07,  Up: Changelog
 
 File: README.info,  Node: 062,  Next: 061,  Prev: 063,  Up: Changelog
 
-5.8 0.6.2
+5.9 0.6.2
 =========
 
 *Fixed*
@@ -1274,8 +1284,8 @@ File: README.info,  Node: 062,  Next: 061,  Prev: 063,  Up: Changelog
 
 File: README.info,  Node: 061,  Next: 06,  Prev: 062,  Up: Changelog
 
-5.9 0.6.1
-=========
+5.10 0.6.1
+==========
 
 *Fixed*
    • In dynamic blocks, links to headings with statistics cookies were
@@ -1292,7 +1302,7 @@ File: README.info,  Node: 061,  Next: 06,  Prev: 062,  Up: Changelog
 
 File: README.info,  Node: 06,  Next: 052,  Prev: 061,  Up: Changelog
 
-5.10 0.6
+5.11 0.6
 ========
 
 *Added*
@@ -1359,7 +1369,7 @@ File: README.info,  Node: 06,  Next: 052,  Prev: 061,  Up: Changelog
 
 File: README.info,  Node: 052,  Next: 051,  Prev: 06,  Up: Changelog
 
-5.11 0.5.2
+5.12 0.5.2
 ==========
 
 *Fixed*
@@ -1370,7 +1380,7 @@ File: README.info,  Node: 052,  Next: 051,  Prev: 06,  Up: Changelog
 
 File: README.info,  Node: 051,  Next: 05,  Prev: 052,  Up: Changelog
 
-5.12 0.5.1
+5.13 0.5.1
 ==========
 
 *Fixed*
@@ -1383,7 +1393,7 @@ File: README.info,  Node: 051,  Next: 05,  Prev: 052,  Up: Changelog
 
 File: README.info,  Node: 05,  Next: 049,  Prev: 051,  Up: Changelog
 
-5.13 0.5
+5.14 0.5
 ========
 
 *Added*
@@ -1424,7 +1434,7 @@ File: README.info,  Node: 05,  Next: 049,  Prev: 051,  Up: Changelog
 
 File: README.info,  Node: 049,  Next: 048,  Prev: 05,  Up: Changelog
 
-5.14 0.4.9
+5.15 0.4.9
 ==========
 
 *Fixed*
@@ -1435,7 +1445,7 @@ File: README.info,  Node: 049,  Next: 048,  Prev: 05,  Up: Changelog
 
 File: README.info,  Node: 048,  Next: 047,  Prev: 049,  Up: Changelog
 
-5.15 0.4.8
+5.16 0.4.8
 ==========
 
 *Fixed*
@@ -1447,7 +1457,7 @@ File: README.info,  Node: 048,  Next: 047,  Prev: 049,  Up: Changelog
 
 File: README.info,  Node: 047,  Next: 046,  Prev: 048,  Up: Changelog
 
-5.16 0.4.7
+5.17 0.4.7
 ==========
 
 *Fixed*
@@ -1460,7 +1470,7 @@ File: README.info,  Node: 047,  Next: 046,  Prev: 048,  Up: Changelog
 
 File: README.info,  Node: 046,  Next: 045,  Prev: 047,  Up: Changelog
 
-5.17 0.4.6
+5.18 0.4.6
 ==========
 
 *Fixed*
@@ -1473,7 +1483,7 @@ File: README.info,  Node: 046,  Next: 045,  Prev: 047,  Up: Changelog
 
 File: README.info,  Node: 045,  Next: 044,  Prev: 046,  Up: Changelog
 
-5.18 0.4.5
+5.19 0.4.5
 ==========
 
 *Fixed*
@@ -1485,7 +1495,7 @@ File: README.info,  Node: 045,  Next: 044,  Prev: 046,  Up: Changelog
 
 File: README.info,  Node: 044,  Next: 043,  Prev: 045,  Up: Changelog
 
-5.19 0.4.4
+5.20 0.4.4
 ==========
 
 *Fixed*
@@ -1497,7 +1507,7 @@ File: README.info,  Node: 044,  Next: 043,  Prev: 045,  Up: Changelog
 
 File: README.info,  Node: 043,  Next: 042,  Prev: 044,  Up: Changelog
 
-5.20 0.4.3
+5.21 0.4.3
 ==========
 
 *Fixed*
@@ -1507,7 +1517,7 @@ File: README.info,  Node: 043,  Next: 042,  Prev: 044,  Up: Changelog
 
 File: README.info,  Node: 042,  Next: 041,  Prev: 043,  Up: Changelog
 
-5.21 0.4.2
+5.22 0.4.2
 ==========
 
 *Fixed*
@@ -1516,7 +1526,7 @@ File: README.info,  Node: 042,  Next: 041,  Prev: 043,  Up: Changelog
 
 File: README.info,  Node: 041,  Next: 04,  Prev: 042,  Up: Changelog
 
-5.22 0.4.1
+5.23 0.4.1
 ==========
 
 *Fixed*
@@ -1526,7 +1536,7 @@ File: README.info,  Node: 041,  Next: 04,  Prev: 042,  Up: Changelog
 
 File: README.info,  Node: 04,  Next: 032,  Prev: 041,  Up: Changelog
 
-5.23 0.4
+5.24 0.4
 ========
 
 _Note:_ The next release, 0.5, may include changes which will require
@@ -1607,7 +1617,7 @@ automatically, as they will be pushed to the ‘master’ branch when ready.
 
 File: README.info,  Node: 032,  Next: 031,  Prev: 04,  Up: Changelog
 
-5.24 0.3.2
+5.25 0.3.2
 ==========
 
 *Fixed*
@@ -1620,7 +1630,7 @@ File: README.info,  Node: 032,  Next: 031,  Prev: 04,  Up: Changelog
 
 File: README.info,  Node: 031,  Next: 03,  Prev: 032,  Up: Changelog
 
-5.25 0.3.1
+5.26 0.3.1
 ==========
 
 *Fixed*
@@ -1630,7 +1640,7 @@ File: README.info,  Node: 031,  Next: 03,  Prev: 032,  Up: Changelog
 
 File: README.info,  Node: 03,  Next: 023,  Prev: 031,  Up: Changelog
 
-5.26 0.3
+5.27 0.3
 ========
 
 *Added*
@@ -1698,7 +1708,7 @@ File: README.info,  Node: 03,  Next: 023,  Prev: 031,  Up: Changelog
 
 File: README.info,  Node: 023,  Next: 022,  Prev: 03,  Up: Changelog
 
-5.27 0.2.3
+5.28 0.2.3
 ==========
 
 *Fixed*
@@ -1708,7 +1718,7 @@ File: README.info,  Node: 023,  Next: 022,  Prev: 03,  Up: Changelog
 
 File: README.info,  Node: 022,  Next: 021,  Prev: 023,  Up: Changelog
 
-5.28 0.2.2
+5.29 0.2.2
 ==========
 
 *Fixed*
@@ -1719,7 +1729,7 @@ File: README.info,  Node: 022,  Next: 021,  Prev: 023,  Up: Changelog
 
 File: README.info,  Node: 021,  Next: 02,  Prev: 022,  Up: Changelog
 
-5.29 0.2.1
+5.30 0.2.1
 ==========
 
 *Fixed*
@@ -1729,7 +1739,7 @@ File: README.info,  Node: 021,  Next: 02,  Prev: 022,  Up: Changelog
 
 File: README.info,  Node: 02,  Next: 01,  Prev: 021,  Up: Changelog
 
-5.30 0.2
+5.31 0.2
 ========
 
 *Added*
@@ -1812,7 +1822,7 @@ File: README.info,  Node: 02,  Next: 01,  Prev: 021,  Up: Changelog
 
 File: README.info,  Node: 01,  Prev: 02,  Up: Changelog
 
-5.31 0.1
+5.32 0.1
 ========
 
 First tagged release.
@@ -1870,76 +1880,77 @@ GPLv3
 
 Tag Table:
 Node: Top225
-Node: Contents1851
-Node: Screenshots1974
-Node: Installation2092
-Node: Quelpa2606
-Node: Helm support3134
-Node: Usage3537
-Node: Commands3935
-Node: org-ql-find4400
-Node: org-ql-open-link5308
-Node: org-ql-refile6163
-Node: org-ql-search6491
-Node: helm-org-ql8422
-Node: org-ql-view8800
-Node: org-ql-view-sidebar9330
-Node: org-ql-view-recent-items9710
-Node: org-ql-sparse-tree10206
-Node: Queries11006
-Node: Non-sexp query syntax12123
-Node: General predicates13882
-Node: Ancestor/descendant predicates20807
-Node: Date/time predicates21935
-Node: Functions / Macros25059
-Node: Agenda-like views25357
-Ref: Function org-ql-block25519
-Node: Listing / acting-on results26780
-Ref: Caching26988
-Ref: Function org-ql-select27901
-Ref: Function org-ql-query30327
-Ref: Macro org-ql (deprecated)32101
-Node: Custom predicates32416
-Ref: Macro org-ql-defpred32640
-Node: Dynamic block36081
-Node: Links38805
-Node: Tips39492
-Node: Changelog39816
-Node: 0840632
-Node: 07443344
-Node: 07343567
-Node: 07244299
-Node: 07145218
-Node: 0746027
-Node: 06348951
-Node: 06249482
-Node: 06149787
-Node: 0650355
-Node: 05253411
-Node: 05153713
-Node: 0554138
-Node: 04955669
-Node: 04855951
-Node: 04756300
-Node: 04656709
-Node: 04557117
-Node: 04457478
-Node: 04357837
-Node: 04258040
-Node: 04158201
-Node: 0458448
-Node: 03262549
-Node: 03162952
-Node: 0363149
-Node: 02366449
-Node: 02266683
-Node: 02166963
-Node: 0267168
-Node: 0171246
-Node: Notes71347
-Node: Comparison with Org Agenda searches71509
-Node: org-sidebar72398
-Node: License72677
+Node: Contents1873
+Node: Screenshots1996
+Node: Installation2114
+Node: Quelpa2628
+Node: Helm support3156
+Node: Usage3559
+Node: Commands3957
+Node: org-ql-find4422
+Node: org-ql-open-link5330
+Node: org-ql-refile6185
+Node: org-ql-search6513
+Node: helm-org-ql8444
+Node: org-ql-view8822
+Node: org-ql-view-sidebar9352
+Node: org-ql-view-recent-items9732
+Node: org-ql-sparse-tree10228
+Node: Queries11028
+Node: Non-sexp query syntax12145
+Node: General predicates13904
+Node: Ancestor/descendant predicates20829
+Node: Date/time predicates21957
+Node: Functions / Macros25081
+Node: Agenda-like views25379
+Ref: Function org-ql-block25541
+Node: Listing / acting-on results26802
+Ref: Caching27010
+Ref: Function org-ql-select27923
+Ref: Function org-ql-query30349
+Ref: Macro org-ql (deprecated)32123
+Node: Custom predicates32438
+Ref: Macro org-ql-defpred32662
+Node: Dynamic block36103
+Node: Links38827
+Node: Tips39514
+Node: Changelog39838
+Node: 081-pre40676
+Node: 0840787
+Node: 07443515
+Node: 07343738
+Node: 07244470
+Node: 07145389
+Node: 0746198
+Node: 06349122
+Node: 06249653
+Node: 06149958
+Node: 0650528
+Node: 05253584
+Node: 05153886
+Node: 0554311
+Node: 04955842
+Node: 04856124
+Node: 04756473
+Node: 04656882
+Node: 04557290
+Node: 04457651
+Node: 04358010
+Node: 04258213
+Node: 04158374
+Node: 0458621
+Node: 03262722
+Node: 03163125
+Node: 0363322
+Node: 02366622
+Node: 02266856
+Node: 02167136
+Node: 0267341
+Node: 0171419
+Node: Notes71520
+Node: Comparison with Org Agenda searches71682
+Node: org-sidebar72571
+Node: License72850
 
 End Tag Table
 

--- a/org-ql.info
+++ b/org-ql.info
@@ -1068,7 +1068,10 @@ File: README.info,  Node: 081-pre,  Next: 08,  Up: Changelog
 5.1 0.8.1-pre
 =============
 
-Nothing new yet.
+*Fixes*
+
+   • Command ‘org-ql-find’ widens the buffer before going to the
+     selected entry.
 
 
 File: README.info,  Node: 08,  Next: 074,  Prev: 081-pre,  Up: Changelog
@@ -1916,41 +1919,41 @@ Node: Links38827
 Node: Tips39514
 Node: Changelog39838
 Node: 081-pre40676
-Node: 0840787
-Node: 07443515
-Node: 07343738
-Node: 07244470
-Node: 07145389
-Node: 0746198
-Node: 06349122
-Node: 06249653
-Node: 06149958
-Node: 0650528
-Node: 05253584
-Node: 05153886
-Node: 0554311
-Node: 04955842
-Node: 04856124
-Node: 04756473
-Node: 04656882
-Node: 04557290
-Node: 04457651
-Node: 04358010
-Node: 04258213
-Node: 04158374
-Node: 0458621
-Node: 03262722
-Node: 03163125
-Node: 0363322
-Node: 02366622
-Node: 02266856
-Node: 02167136
-Node: 0267341
-Node: 0171419
-Node: Notes71520
-Node: Comparison with Org Agenda searches71682
-Node: org-sidebar72571
-Node: License72850
+Node: 0840871
+Node: 07443599
+Node: 07343822
+Node: 07244554
+Node: 07145473
+Node: 0746282
+Node: 06349206
+Node: 06249737
+Node: 06150042
+Node: 0650612
+Node: 05253668
+Node: 05153970
+Node: 0554395
+Node: 04955926
+Node: 04856208
+Node: 04756557
+Node: 04656966
+Node: 04557374
+Node: 04457735
+Node: 04358094
+Node: 04258297
+Node: 04158458
+Node: 0458705
+Node: 03262806
+Node: 03163209
+Node: 0363406
+Node: 02366706
+Node: 02266940
+Node: 02167220
+Node: 0267425
+Node: 0171503
+Node: Notes71604
+Node: Comparison with Org Agenda searches71766
+Node: org-sidebar72655
+Node: License72934
 
 End Tag Table
 


### PR DESCRIPTION
These commands were removed in 5768c685adc7c6e85c17cfec358aa8a0e368310b, but they were still mentioned in the release that was going to incorporate those two functions, v0.7.