### PR TITLE
Fix: (org-ql-regexp-part-ts-data) Accept day of week ending with '.'

### DIFF
--- a/org-ql.el
+++ b/org-ql.el
@@ -157,7 +157,7 @@ This list should not contain any duplicates."))
 (defvar org-ql-regexp-part-ts-date
   (rx (repeat 4 digit) "-" (repeat 2 digit) "-" (repeat 2 digit)
       ;; Day of week
-      (optional " " (1+ alpha)))
+      (optional " " (1+ alpha) (optional ".")))
   "Matches the inner, date part of an Org timestamp, both active and inactive.
 Also matches optional day-of-week.  Used to build other timestamp
 regexps.")


### PR DESCRIPTION
In French, days of week are ending with a dot. Before this commit, timestamps in this language (like `<2024-05-30 jeu.>`) where just ignored by `org-ql`.

Fixes #432