### PR TITLE
Fix: Use equal to compare lists

### DIFF
--- a/org-ql-search.el
+++ b/org-ql-search.el
@@ -186,7 +186,7 @@ necessary."
   (interactive (list (org-ql-view--complete-buffers-files)
                      (read-string "Query: " (when org-ql-view-query
                                               (format "%S" org-ql-view-query)))
-                     :narrow (or org-ql-view-narrow (eq current-prefix-arg '(4)))
+                     :narrow (or org-ql-view-narrow (equal current-prefix-arg '(4)))
                      :super-groups (org-ql-view--complete-super-groups)
                      :sort (org-ql-view--complete-sort)))
   ;; NOTE: Using `with-temp-buffer' is a hack to work around the fact that `make-local-variable'


### PR DESCRIPTION
`eq` is not a proper way to compare the structures of two Lisp objects. I spontaneously discovered this trivial mistake while investigating on another issue, but nobody pointed it out before? 