### PR TITLE
Fix: (org-ql-view--font-lock-as-org) Mark buffer as not modified

### DIFF
--- a/org-ql-view.el
+++ b/org-ql-view.el
@@ -542,7 +542,8 @@ with human-readable strings."
       (insert s)
       (font-lock-ensure)
       (prog1 (buffer-string)
-        (erase-buffer)))))
+        (erase-buffer)
+        (set-buffer-modified-p nil)))))
 
 (defun org-ql-view--buffer (&optional name)
   "Return `org-ql-view' buffer, creating it if necessary.

--- a/org-ql-view.el
+++ b/org-ql-view.el
@@ -537,13 +537,13 @@ with human-readable strings."
                     (with-current-buffer (get-buffer-create " *org-ql-view--font-lock-as-org*")
                       (buffer-disable-undo)
                       (org-mode)
+                      (setq buffer-save-without-query nil)
                       (current-buffer)))))
     (with-current-buffer buffer
       (insert s)
       (font-lock-ensure)
       (prog1 (buffer-string)
-        (erase-buffer)
-        (set-buffer-modified-p nil)))))
+        (erase-buffer)))))
 
 (defun org-ql-view--buffer (&optional name)
   "Return `org-ql-view' buffer, creating it if necessary.


### PR DESCRIPTION
Mark the ` *org-ql-view--font-lock-as-org*' buffer as not modified to prevent Emacs from prompting the user to save it.