### PR TITLE
Fix oclosure lexical-binding assertion error due to recent change in peg.el in Emacs master

### DIFF
--- a/org-ql.el
+++ b/org-ql.el
@@ -1003,7 +1003,8 @@ value of `org-ql-predicates')."
                                          (peg-run (peg ,(caar pexs))
                                                   (lambda (failures)
                                                     (when org-ql-signal-peg-failure
-                                                      (peg-signal-failure failures)))))))))
+                                                      (peg-signal-failure failures)))))
+                                      t))))
                         (pcase parsed-sexp
                           (`(,one-predicate) one-predicate)
                           (`(,_ . ,_) (cons boolean (reverse parsed-sexp)))


### PR DESCRIPTION
Hi Adam,

A recent change made by Stefan in peg.el in the master branch broke org-ql because of lexical-binding assertion error.  I filed a bug report about this upstream in https://debbugs.gnu.org/cgi/bugreport.cgi?bug=74735.

Stefan provided a simple patch to fix the issue on org-ql which I'm sending here as a PR.