### PR TITLE
Allow `org-ql-refile` to handle values for `org-refile-targets` where the symbol in a given cons cell has a variable value

### DIFF
--- a/org-ql-find.el
+++ b/org-ql-find.el
@@ -122,7 +122,7 @@ which see (but only the files are used)."
                                                                          ((and (pred listp) files) files)))
                                                              (symbol (pcase (eval files-spec)
                                                                        ((and (pred stringp) file) (list file))
-                                                                         ((and (pred listp) files) files)))
+                                                                       ((and (pred listp) files) files)))
                                                              (list files-spec)))))))
                  (list (org-ql-completing-read buffers-files :prompt "Refile to: "))))
   (let ((buffer (or (buffer-base-buffer (marker-buffer marker))
@@ -139,6 +139,7 @@ which see (but only the files are used)."
                  nil
                  ;; Position
                  marker))))
+
 ;;;###autoload
 (defun org-ql-find-in-agenda ()
   "Call `org-ql-find' on `org-agenda-files'."

--- a/org-ql-find.el
+++ b/org-ql-find.el
@@ -117,9 +117,12 @@ which see (but only the files are used)."
                                            (cl-loop for (files-spec . _candidate-spec) in org-refile-targets
                                                     append (cl-typecase files-spec
                                                              (null (list (current-buffer)))
-                                                             (symbol (pcase (funcall files-spec)
+                                                             (function (pcase (funcall files-spec)
+                                                                         ((and (pred stringp) file) (list file))
+                                                                         ((and (pred listp) files) files)))
+                                                             (symbol (pcase (eval files-spec)
                                                                        ((and (pred stringp) file) (list file))
-                                                                       ((and (pred listp) files) files)))
+                                                                         ((and (pred listp) files) files)))
                                                              (list files-spec)))))))
                  (list (org-ql-completing-read buffers-files :prompt "Refile to: "))))
   (let ((buffer (or (buffer-base-buffer (marker-buffer marker))
@@ -136,7 +139,6 @@ which see (but only the files are used)."
                  nil
                  ;; Position
                  marker))))
-
 ;;;###autoload
 (defun org-ql-find-in-agenda ()
   "Call `org-ql-find' on `org-agenda-files'."


### PR DESCRIPTION
This fixes #487. We simply add a test to make sure `files-spec` has a function value before applying `funcall` to it, and handle the case where `files-spec` has a variable value separately.