### PR TITLE
A few backwards compatibility changes to match org-agenda

### DIFF
--- a/org-ql-search.el
+++ b/org-ql-search.el
@@ -260,7 +260,7 @@ automatically from the query."
       ;;  (org-agenda--insert-overriding-header (or org-ql-block-header (org-ql-agenda--header-line-format from query)))
       (insert (org-add-props (or org-ql-block-header (org-ql-view--header-line-format
                                                       :buffers-files from :query query))
-                  nil 'face 'org-agenda-structure) "\n")
+                  nil 'face 'org-agenda-structure 'org-agenda-type 'search) "\n")
       ;; Calling `org-agenda-finalize' should be unnecessary, because in a "series" agenda,
       ;; `org-agenda-multi' is bound non-nil, in which case `org-agenda-finalize' does nothing.
       ;; But we do call `org-agenda-finalize-entries', which allows `org-super-agenda' to work.

--- a/org-ql-view.el
+++ b/org-ql-view.el
@@ -974,6 +974,7 @@ return an empty string."
            ;; FIXME: Use proper prefix
            (concat "  " it)
            (org-add-props it properties
+             'txt string
              'org-agenda-type 'search
              'org-category category
              'todo-state todo-keyword

--- a/org-ql-view.el
+++ b/org-ql-view.el
@@ -937,11 +937,16 @@ return an empty string."
                            (display-warning 'org-ql (format "No marker found for item: %s" title))
                            (org-element-property :tags element))
                        (org-element-property :tags element)))
-           (tag-string (when tag-list
-                         (--> tag-list
-                              (s-join ":" it)
-                              (s-wrap it ":")
-                              (org-add-props it nil 'face 'org-tag))))
+           (tags-to-show
+            (or (and org-agenda-hide-tags-regexp
+                     (--remove (string-match-p org-agenda-hide-tags-regexp it)
+                               tag-list))
+                tag-list))
+           (tag-string (when tags-to-show
+                         (--> tags-to-show
+                           (s-join ":" it)
+                           (s-wrap it ":")
+                           (org-add-props it nil 'face 'org-tag))))
            (category (or (org-element-property :CATEGORY element)
                          (when-let ((marker (or (org-element-property :org-hd-marker element)
                                                 (org-element-property :org-marker element))))


### PR DESCRIPTION
Respect org-agenda-hide-tags-regexp. 

Add text properties matching what regular org-agenda blocks add. 