### PR TITLE
Add :limit keyword support

### DIFF
--- a/org-ql-search.el
+++ b/org-ql-search.el
@@ -149,7 +149,7 @@ Runs `org-occur-hook' after making the sparse tree."
       num-results)))
 
 ;;;###autoload
-(cl-defun org-ql-search (buffers-files query &key narrow super-groups sort title
+(cl-defun org-ql-search (buffers-files query &key narrow super-groups sort title limit
                                        (buffer org-ql-view-buffer))
   "Search for QUERY with `org-ql'.
 Interactively, prompt for these variables:
@@ -205,7 +205,8 @@ necessary."
            (results (org-ql-select buffers-files query
                       :action 'element-with-markers
                       :narrow narrow
-                      :sort sort))
+                      :sort sort
+                      :limit limit))
            (strings (-map #'org-ql-view--format-element results))
            (buffer (or buffer (format "%s %s*" org-ql-view-buffer-name-prefix (or title query))))
            (header (org-ql-view--header-line-format
@@ -214,6 +215,7 @@ necessary."
            (org-ql-view-buffers-files buffers-files)
            (org-ql-view-query query)
            (org-ql-view-sort sort)
+           (org-ql-view-limit limit)
            (org-ql-view-narrow narrow)
            (org-ql-view-super-groups super-groups)
            (org-ql-view-title title))
@@ -242,10 +244,10 @@ automatically from the query."
                         ('nil (org-agenda-files nil 'ifmode))
                         (_ (prog1 org-agenda-restrict
                              (with-current-buffer org-agenda-restrict
-			       ;; Narrow the buffer; remember to widen it later.
-			       (setf old-beg (point-min) old-end (point-max)
+			                   ;; Narrow the buffer; remember to widen it later.
+			                   (setf old-beg (point-min) old-end (point-max)
                                      narrow-p t)
-			       (narrow-to-region org-agenda-restrict-begin org-agenda-restrict-end))))))
+			                   (narrow-to-region org-agenda-restrict-begin org-agenda-restrict-end))))))
                 (items (org-ql-select from query
                          :action 'element-with-markers
                          :narrow narrow-p)))

--- a/tests/test-org-ql.el
+++ b/tests/test-org-ql.el
@@ -2359,6 +2359,18 @@ with keyword arg NOW in PLIST."
                                               :buffer link-buffer)
                     :to-throw 'user-error '("Views that search non-file-backed buffers can't be linked to"))))))
 
+    (describe "org-ql-select with :limit"
+      
+      (it "returns only N results when :limit is given"
+        (org-ql-expect ('(ancestors))
+          '("Take over the world" "Skype with president of Antarctica" "Take over Mars" "Visit Mars" "Take over the moon" "Visit the moon" "Practice leaping tall buildings in a single bound" "Renew membership in supervillain club" "Learn universal sign language" "/r/emacs" "Shop for groceries" "Sunrise/sunset" "Rewrite Emacs in Common Lisp" "Write a symphony"))
+        (org-ql-expect ('(ancestors) :limit 3)
+          '("Take over the world" "Skype with president of Antarctica" "Take over Mars")))
+
+      (it "returns all results when :limit is nil"
+        (org-ql-expect ('(ancestors) :limit nil)
+          '("Take over the world" "Skype with president of Antarctica" "Take over Mars" "Visit Mars" "Take over the moon" "Visit the moon" "Practice leaping tall buildings in a single bound" "Renew membership in supervillain club" "Learn universal sign language" "/r/emacs" "Shop for groceries" "Sunrise/sunset" "Rewrite Emacs in Common Lisp" "Write a symphony"))))
+    
     ;; MAYBE: Also test `org-ql-views', although I already know it works now.
     ;; (describe "org-ql-views")
     ))


### PR DESCRIPTION
Add a `:limit` parameter to the `org-ql-select`, `org-ql-query`, and `org-ql-search` family of functions, along with persistence and UI support in `org-ql-view`.

An example use case:
```emacs-lisp
  ;; Use “g” to refresh and see 5 (new) random entries;
  ;; or press “v l 30 RET r” to view 30 entries.
  (org-ql-search 
    org-agenda-files
    '(tags "ConsumeContent")
    :title "Consume content that will make me happy"
    :limit 5
    :sort (lambda (x y) (pcase (random 3)
                     (0 nil)
                     (1 1)
                     (2 -1))))
```

This resolves https://github.com/alphapapa/org-ql/issues/326