### PR TITLE
Set completion-styles via setq-local rather than by let-binding

### DIFF
--- a/org-ql-completing-read.el
+++ b/org-ql-completing-read.el
@@ -332,26 +332,26 @@ single predicate)."
       ;; ensuring all of the BUFFERS-FILES are loaded and initialized before calling
       ;; `completing-read'.
       (mapc #'org-ql--ensure-buffer buffers-files)
-      (let* ((completion-styles '(org-ql-completing-read))
-             (completion-styles-alist (cons (list 'org-ql-completing-read #'try #'all "Org QL Find")
-                                            completion-styles-alist))
-             (selected
-              (minibuffer-with-setup-hook
-                  (lambda ()
-                    (use-local-map (make-composed-keymap org-ql-completing-read-map (current-local-map))))
-                (cl-letf* (((symbol-function 'org-ql-completing-read-export)
-                            (lambda ()
-                              (interactive)
-                              (run-at-time 0 nil
-                                           #'org-ql-search
-                                           buffers-files
-                                           (minibuffer-contents-no-properties))
-                              (if (fboundp 'minibuffer-quit-recursive-edit)
-                                  (minibuffer-quit-recursive-edit)
-                                (abort-recursive-edit))))
-                           ((symbol-function 'embark-export)
-                            (symbol-function 'org-ql-completing-read-export)))
-                  (completing-read prompt #'collection nil t)))))
+      (let ((selected
+             (minibuffer-with-setup-hook
+                 (lambda ()
+                   (setq-local completion-styles '(org-ql-completing-read))
+                   (setq-local completion-styles-alist (cons (list 'org-ql-completing-read #'try #'all "Org QL Find")
+                                                             completion-styles-alist))
+                   (use-local-map (make-composed-keymap org-ql-completing-read-map (current-local-map))))
+               (cl-letf* (((symbol-function 'org-ql-completing-read-export)
+                           (lambda ()
+                             (interactive)
+                             (run-at-time 0 nil
+                                          #'org-ql-search
+                                          buffers-files
+                                          (minibuffer-contents-no-properties))
+                             (if (fboundp 'minibuffer-quit-recursive-edit)
+                                 (minibuffer-quit-recursive-edit)
+                               (abort-recursive-edit))))
+                          ((symbol-function 'embark-export)
+                           (symbol-function 'org-ql-completing-read-export)))
+                 (completing-read prompt #'collection nil t)))))
         ;; (debug-message "SELECTED:%S  KEYS:%S" selected (hash-table-keys table))
         (or (gethash selected table)
             ;; If there are completions in the table, but none of them exactly match the user input


### PR DESCRIPTION
When the completion-styles are bound they affect all recursive minibuffers as well, overriding the user's completion setup! Using setq-local instead ensures the org-ql completion settings are only applied for the org-ql-completing-read minibuffer.

I would have run across this problem simply because I tend to use recursive minibuffers, but this also is a problem for people who do not enable recursive minibuffers but use Embark to, say, refile a heading from org-ql-find (Embark temporarily activates recursive minibuffers).
